### PR TITLE
PR #16 (fix/apiFunction)

### DIFF
--- a/mu-plugins/central-hub/src/config-store/internals.php
+++ b/mu-plugins/central-hub/src/config-store/internals.php
@@ -116,3 +116,4 @@ function str_starts_with( $haystack, $needle, $encoding = 'UTF-8' ) {
 
 	return ( mb_substr( $haystack, 0, $needle_length, $encoding ) === $needle );
 }
+

--- a/mu-plugins/central-hub/src/config-store/internals.php
+++ b/mu-plugins/central-hub/src/config-store/internals.php
@@ -107,5 +107,12 @@ function _merge_with_defaults( array $config, array $defaults ) {
 function str_starts_with( $haystack, $needle, $encoding = 'UTF-8' ) {
 	$needle_length = mb_strlen( $needle, $encoding );
 
+	// Using string lengths, check if given a haystack and needle to compare.
+	if ( $needle_length == 0 || mb_strlen( $haystack, $encoding ) == 0 ) {
+		throw new \InvalidArgumentException(
+			sprintf( 'The haystack and needle cannot be empty. Given: haystack [%s] and needle of [%s].', $haystack, $needle )
+		);
+	}
+
 	return ( mb_substr( $haystack, 0, $needle_length, $encoding ) === $needle );
 }


### PR DESCRIPTION
Fix the structure of the function `str_starts_with()` so that the class `\InvalidArgumentException` is called from the global scope and not the file namespace. 

This change is needed so that future branches checked out from `development` incorporate this fix. 