### PR TITLE
Improve test suites

### DIFF
--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfig.php
@@ -33,14 +33,15 @@ class Tests_GetConfig extends Test_Case {
 				'ccc' => 'ddd'
 			]
 		];
-		_the_store( 'foo', $config );
-		$expected = getConfig( 'foo' );
+		// Store the configuration before we start the test.
+		_the_store( __METHOD__, $config );
 
-		$this->assertArrayHasKey( 'foo', $expected );
-		$this->assertSame( $expected, $config );
+		$actual = getConfig( __METHOD__ );
+		$this->assertArrayHasKey( 'foo', $actual );
+		$this->assertSame( $actual, $config );
 
 		// Clean up _the_store.
-		_the_store( 'foo', null, true );
+		_the_store( __METHOD__, null, true );
 	}
 
 	/**
@@ -49,15 +50,14 @@ class Tests_GetConfig extends Test_Case {
 	public function test_should_throw_exception_when_key_not_found_in_config() {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Configuration for [foo] does not exist in the ConfigStore' );
-
 		getConfig( 'foo' );
+
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Configuration for [this_key_does_not_exist] does not exist in the ConfigStore' );
-
 		getConfig( 'this_key_does_not_exist' );
+
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Configuration for [__METHOD__] does not exist in the ConfigStore' );
-
 		getConfig( __METHOD__ );
 	}
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
@@ -32,7 +32,7 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	}
 
 	/**
-	 *  Test should return array when $path_to_file is given.
+	 *  Test _load_config_from_filesystem() should return the configuration array when $path_to_file is given.
 	 */
 	public function test_should_return_array_when_path_to_file_is_given() {
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_mergeWithDefaults.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_mergeWithDefaults.php
@@ -1,6 +1,6 @@
 <?php
 /**
- *  Tests for _merge_with_defaults
+ *  Tests for _merge_with_defaults()
  *
  * @package    spiralWebDb\centralHub\Tests\Unit\ConfigStore
  * @since      1.3.0
@@ -32,14 +32,14 @@ class Tests_MergeWithDefaults extends Test_Case {
 	}
 
 	/**
-	 * Test should return empty when empty arrays are given.
+	 * Test _merge_with_defaults() should return an empty array when empty arrays are given.
 	 */
 	public function test_should_return_empty_when_empty_arrays_given() {
 		$this->assertEmpty( _merge_with_defaults( [], [] ) );
 	}
 
 	/**
-	 * Test should return config when defaults are empty.
+	 * Test _merge_with_defaults() should return the given config when defaults are empty.
 	 */
 	public function test_should_return_config_when_defaults_are_empty() {
 		$config = [
@@ -53,7 +53,7 @@ class Tests_MergeWithDefaults extends Test_Case {
 	}
 
 	/**
-	 * Test should return defaults when config is empty.
+	 * Test _merge_with_defaults() should return the defaults when config is empty.
 	 */
 	public function test_should_return_defaults_when_config_is_empty() {
 		$defaults = [
@@ -67,7 +67,7 @@ class Tests_MergeWithDefaults extends Test_Case {
 	}
 
 	/**
-	 *  Test should merge configuration with default array parameters
+	 *  Test _merge_with_defaults() should return the merged config parameters and default parameters
 	 */
 	public function test_should_merge_config_with_default_array_parameters() {
 		$config = [

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getConfig.php
@@ -36,7 +36,7 @@ class Tests_GetConfig extends Test_Case {
 	 * Test getConfig() should return the requested configuration when a valid store key is given.
 	 */
 	public function test_should_return_configuration_when_store_key_is_given() {
-		$config = [
+		$expected = [
 			'foo' => [
 				'aaa' => 'bbb',
 				'ccc' => 'ddd',
@@ -46,11 +46,11 @@ class Tests_GetConfig extends Test_Case {
 		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )
 			->once()
 			->with( __METHOD__ )
-			->andReturn( $config );
+			->andReturn( $expected );
 
-		$expected = getConfig( __METHOD__ );
-		$this->assertArrayHasKey( 'foo', $expected );
-		$this->assertSame( $expected, $config );
+		$actual = getConfig( __METHOD__ );
+		$this->assertArrayHasKey( 'foo', $actual );
+		$this->assertSame( $actual, $expected );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/strStartsWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/strStartsWith.php
@@ -32,7 +32,7 @@ class Tests_StringStartsWith extends Test_Case {
 	}
 
 	/*
-	 *  Test should return true when substring starts with and matches haystack.
+	 *  Test str_starts_with() should return true when substring starts with and matches haystack.
 	 */
 	public function test_should_return_true_when_substring_starts_with() {
 		$this->assertTrue( str_starts_with( 'Hello World!', 'Hello' ) );
@@ -41,7 +41,7 @@ class Tests_StringStartsWith extends Test_Case {
 	}
 
 	/**
-	 * Test should return false when substring does not start with & match haystack.
+	 * Test str_starts_with() should return false when substring does not start with & match haystack.
 	 */
 	public function test_should_return_false_when_substring_does_not_start() {
 		$this->assertFalse( str_starts_with( 'Hello World', 'World' ) );
@@ -51,28 +51,25 @@ class Tests_StringStartsWith extends Test_Case {
 	}
 
 	/**
-	 * Test should throw exception when string length ($haystack or $needle) is empty.
+	 * Test str_starts_with() should throw exception when string length ($haystack or $needle) is empty.
 	 */
 	public function test_should_throw_exception_when_string_is_empty() {
 		$this->expectException( \InvalidArgumentException::class );
 		$this->expectExceptionMessage(
 			'The haystack and needle cannot be empty. Given: haystack [Cornerstone] and needle of [].'
 		);
-
 		str_starts_with( 'Cornerstone', '' );
 
 		$this->expectException( \InvalidArgumentException::class );
 		$this->expectExceptionMessage(
 			'The haystack and needle cannot be empty. Given: haystack [] and needle of [WordPress].'
 		);
-
 		str_starts_with( '', 'WordPress' );
 
 		$this->expectException( \InvalidArgumentException::class );
 		$this->expectExceptionMessage(
 			'The haystack and needle cannot be empty. Given: haystack [] and needle of [].'
 		);
-
 		str_starts_with( '', '' );
 	}
 }


### PR DESCRIPTION
This PR includes the following improvements to the current test suites:

1. Improves each test method's DocBlock for consistency.
2. Fixed formatting.
3. Standardizes the variables `$actual` and `$expected` where:
     - actual is what is returned when invoking the function being tests
     - expected is what the test expects the returned value to be