### PR TITLE
Add exceptions to _load_config_from_filesystem for no store key or no config params

### DIFF
--- a/mu-plugins/central-hub/src/config-store/internals.php
+++ b/mu-plugins/central-hub/src/config-store/internals.php
@@ -59,22 +59,34 @@ function _the_store( $store_key = '', $config_to_store = array(), $remove = null
 }
 
 /**
- * Load a configuration from the filesystem, returning its
- * storage key and configuration parameters.
+ * Load a configuration from the filesystem, returning its storage key and configuration parameters.
  *
  * @since 1.0.0
  *
  * @param string $path_to_file Absolute path to the config file.
  *
- * @return array
+ * @return array returns an array with storage key => config parameters.
+ * @throws \Exception
  */
 function _load_config_from_filesystem( $path_to_file ) {
-	$config = (array) require $path_to_file;
+	$config    = (array) require $path_to_file;
 
-	return array(
-		key( $config ),
-		current( $config ),
-	);
+	$store_key = key( $config );
+	if ( empty( $store_key ) ) {
+		throw new \Exception(
+			sprintf( 'No store key exists in the %s configuration file.', esc_attr( $path_to_file ) )
+		);
+	}
+
+	$config_params = current( $config );
+	if ( empty( $config_params ) ) {
+		throw new \Exception(
+			sprintf( 'No configuration parameters exist for store key [%s] in the %s configuration file.',
+				esc_attr( $store_key ), esc_attr( $path_to_file ) )
+		);
+	}
+
+	return [ $store_key, $config_params ];
 }
 
 /**

--- a/mu-plugins/central-hub/tests/phpunit/fixtures/config-with-params-only.php
+++ b/mu-plugins/central-hub/tests/phpunit/fixtures/config-with-params-only.php
@@ -12,8 +12,10 @@
 
 namespace spiralWebDb\centralHub\Tests\Fixtures;
 
-return  [
+return [
+	[
 		'aaa' => 'bbb',
-		'ccc' => 'ddd'
+		'ccc' => 'ddd',
+	],
 ];
 

--- a/mu-plugins/central-hub/tests/phpunit/fixtures/config-with-params-only.php
+++ b/mu-plugins/central-hub/tests/phpunit/fixtures/config-with-params-only.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ *  Test data for the ConfigStore API.
+ *  Store key is empty and configuration parameters exist.
+ *
+ * @package    spiralWebDb\centralHub\Tests\Fixtures
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Fixtures;
+
+return  [
+		'aaa' => 'bbb',
+		'ccc' => 'ddd'
+];
+

--- a/mu-plugins/central-hub/tests/phpunit/fixtures/config-with-store-key-only.php
+++ b/mu-plugins/central-hub/tests/phpunit/fixtures/config-with-store-key-only.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ *  Test data for the ConfigStore API.
+ *  Store key exists and configuration parameters are empty.
+ *
+ * @package    spiralWebDb\centralHub\Tests\Fixtures
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Fixtures;
+
+return  [
+	'foo' => []
+];
+

--- a/mu-plugins/central-hub/tests/phpunit/fixtures/empty-config.php
+++ b/mu-plugins/central-hub/tests/phpunit/fixtures/empty-config.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ *  Empty configuration file with no store key or configuration parameters.
+ *
+ * @package    spiralWebDb\centralHub\Tests\Fixtures
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Fixtures;
+
+return [];

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
@@ -52,14 +52,13 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 *  and parameters exist.
 	 */
 	public function test_should_throw_exception_when_no_store_key() {
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-params-only.php';
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage(
-			sprintf( 'No store key exists in the [path_to_file] configuration file.', 'path_to_file' )
+			sprintf( 'No store key exists in the %s configuration file.', $path_to_file )
 		);
-		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-params-only.php';
 		_load_config_from_filesystem( $path_to_file );
 	}
-
 
 	/**
 	 * Test _load_config_from_filesystem() should throw an Exception when configuration store key exists and

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
@@ -69,15 +69,17 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	}
 
 	/**
-	 * Test _load_config_from_filesystem() should throw an Exception when configuration store key exists and
-	 *  parameters are empty.
+	 * Test _load_config_from_filesystem() should throw an Exception when the configuration parameters are empty.
 	 */
-	public function test_should_throw_exception_when_config_store_key_exists_and_no_parameters() {
+	public function test_should_throw_exception_when_config_params_empty() {
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-store-key-only.php';
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage(
-			sprintf( 'No configuration parameters exist for store key [%s] in the %s configuration file.',
-				'foo', $path_to_file ) );
+			sprintf(
+				'No configuration parameters exist for store key [foo] in the %s configuration file.',
+				$path_to_file
+			)
+		);
 		_load_config_from_filesystem( $path_to_file );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
@@ -1,6 +1,6 @@
 <?php
 /**
- *  Tests for _load_config_from_filesystem
+ *  Tests for _load_config_from_filesystem()
  *
  * @package    spiralWebDb\centralHub\Tests\Unit\ConfigStore
  * @since      1.3.0
@@ -11,6 +11,7 @@
 
 namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
 
+use Brain\Monkey;
 use function KnowTheCode\ConfigStore\_load_config_from_filesystem;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
@@ -45,4 +46,36 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 		$this->assertSame( 'foo', $actual[0] );
 		$this->assertSame( $expected, $actual[1] );
 	}
+
+	/**
+	 * Test _load_config_from_filesystem() should throw an Exception when configuration store key is empty
+	 *  and parameters exist.
+	 */
+	public function test_should_throw_exception_when_no_store_key() {
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage(
+			sprintf( 'No store key exists in the [path_to_file] configuration file.', 'path_to_file' )
+		);
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-params-only.php';
+		_load_config_from_filesystem( $path_to_file );
+	}
+
+
+	/**
+	 * Test _load_config_from_filesystem() should throw an Exception when configuration store key exists and
+	 *  parameters are empty.
+	 */
+//	public function test_should_throw_an_exception_when_config_store_key_exists_and_parameters_are_empty() {
+//		$this->expectException( \Exception::class );
+//		$this->expectExceptionMessage(
+//			sprintf( 'No configuration parameters exist for store key [store_key] in the [path_to_file] configuration file.',
+//				'store_key', 'path_to_file' ) );
+//	}
+
+	/**
+	 * Test _load_config_from_filesystem() should throw an Exception when the configuration store key and
+	 *  parameters are both empty.
+	 */
+
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
@@ -48,14 +48,22 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	}
 
 	/**
-	 * Test _load_config_from_filesystem() should throw an Exception when configuration store key is empty
-	 *  and parameters exist.
+	 * Test _load_config_from_filesystem() should throw an Exception when configuration no store key exists.
 	 */
 	public function test_should_throw_exception_when_no_store_key() {
+		// Test when no store key but has configuration parameters.
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-params-only.php';
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage(
 			sprintf( 'No store key exists in the %s configuration file.', $path_to_file )
+		);
+		_load_config_from_filesystem( $path_to_file );
+
+		// Test when no store key or configuration parameters.
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/empty-config.php';
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage(
+			sprintf( 'No store key exists in the [%s] configuration file.', $path_to_file )
 		);
 		_load_config_from_filesystem( $path_to_file );
 	}

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
@@ -72,17 +72,13 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 * Test _load_config_from_filesystem() should throw an Exception when configuration store key exists and
 	 *  parameters are empty.
 	 */
-//	public function test_should_throw_an_exception_when_config_store_key_exists_and_parameters_are_empty() {
-//		$this->expectException( \Exception::class );
-//		$this->expectExceptionMessage(
-//			sprintf( 'No configuration parameters exist for store key [store_key] in the [path_to_file] configuration file.',
-//				'store_key', 'path_to_file' ) );
-//	}
-
-	/**
-	 * Test _load_config_from_filesystem() should throw an Exception when the configuration store key and
-	 *  parameters are both empty.
-	 */
-
+	public function test_should_throw_exception_when_config_store_key_exists_and_no_parameters() {
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-store-key-only.php';
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage(
+			sprintf( 'No configuration parameters exist for store key [%s] in the %s configuration file.',
+				'foo', $path_to_file ) );
+		_load_config_from_filesystem( $path_to_file );
+	}
 }
 


### PR DESCRIPTION
@hellofromtonya I'm trying to test edge case #5: 

>When there’s no key in the configuration array that was loaded from the filesystem, the values for:
```list( $store_key, $config ) = _load_config_from_filesystem( $path_to_file );```

>`$store_key` will be `NULL`

>and if the array is empty, then `$config` will be `False`.

>If there’s no key, something else should happen to alert that there was no key in the configuration file.

Choices:

>1. Throw an error.
>2. Return something like `False` or `Null`."

Trying to throw an \Exception from `_load_config_from_filesystem`. 

Message: Failed asserting that exception of type "Exception" is thrown.

I'm trying to avoid using a test fixture inside `_load_config_from_filesystem` and mock the function parameter `$path_to_file` with Brain Monkey instead.
