### PR TITLE
Add tests for Config Store API function: `loadConfigFromFilesystem`

### DIFF
--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfigFromFilesystem.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ *  Tests for external API function loadConfigFromFilesystem()
+ *
+ * @package    spiralWebDb\centralHub\Tests\Integration\ConfigStore
+ * @since      1.3.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
+
+use Brain\Monkey;
+use function KnowTheCode\ConfigStore\_the_store;
+use function KnowTheCode\ConfigStore\loadConfigFromFilesystem;
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+
+
+/**
+ * Class Tests_LoadConfigFromFilesystem
+ *
+ * @package spiralWebDb\centralHub\Tests\Integration\ConfigStore
+ * @group   config-store
+ */
+class Tests_LoadConfigFromFilesystem extends Test_Case {
+
+	/**
+	 * Test loadConfigFromFilesystem() should merge defaults with config and return a store key.
+	 */
+	public function test_should_merge_defaults_and_return_store_key() {
+		$path_to_file  = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
+		$defaults      = [
+			'aaa' => 37,
+			'eee' => 'Coding is fun!',
+		];
+		$merged_config = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
+			'eee' => 'Coding is fun!',
+		];
+
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file, $defaults ) );
+		$this->assertEquals( $merged_config, _the_store( 'foo' ) );
+	}
+
+	/**
+	 * Test loadConfigFromFilesystem() should store a config and return the store key.
+	 */
+	public function test_should_store_a_config_and_return_store_key() {
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
+		$config       = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
+		];
+
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
+		$this->assertSame( $config, _the_store( 'foo' ) );
+	}
+
+	/**
+	 * Test loadConfigFromFilesystem() should overwrite stored configuration and return store key from
+	 * file configuration.
+	 */
+	public function test_should_overwrite_store_and_return_store_key_from_file_config() {
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
+		$config       = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
+		];
+
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
+		$this->assertSame( $config, _the_store( 'foo' ) );
+	}
+
+	/**
+	 * Test loadConfigFromFilesystem() should overwrite stored configuration and return store key from
+	 * file configuration.
+	 */
+	public function test_should_throw_exception_when_no_store_key() {
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-params-only.php';
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage(
+			sprintf( 'No store key exists in the %s configuration file.', $path_to_file )
+		);
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_merge_with_defaults' )->never();
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )->never();
+
+		loadConfigFromFilesystem( $path_to_file );
+	}
+
+	/**
+	 * Test loadConfigFromFilesystem() should throw an Exception when the configuration parameters are empty.
+	 */
+	public function test_should_throw_exception_when_config_params_empty() {
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-store-key-only.php';
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage(
+			sprintf(
+				'No configuration parameters exist for store key [foo] in the %s configuration file.',
+				$path_to_file
+			)
+		);
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_merge_with_defaults' )->never();
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )->never();
+
+		loadConfigFromFilesystem( $path_to_file );
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_loadConfigFromFilesystem.php
@@ -16,12 +16,12 @@ use function KnowTheCode\ConfigStore\_load_config_from_filesystem;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
 /**
- * Class Tests_LoadConfigFromFilesystem
+ * Class Tests__LoadConfigFromFilesystem
  *
  * @package spiralWebDb\centralHub\Tests\Unit\ConfigStore
  * @group   config-store
  */
-class Tests_LoadConfigFromFilesystem extends Test_Case {
+class Tests__LoadConfigFromFilesystem extends Test_Case {
 
 	/**
 	 * Prepares the test environment before each test.

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -71,5 +71,19 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 		loadConfigFromFilesystem( 'path/to/file.php' );
 	}
 
+	/**
+	 * Test loadConfigFromFilesystem() should overwrite stored configuration and
+	 *   return store key from file configuration.
+	 */
+	public function test_should_overwrite_store_and_return_store_key_from_file_config() {
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->with( 'baz', 'config_to_store' )
+			->andReturn( 'baz');
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
+		loadConfigFromFilesystem( $path_to_file );
+
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
+	}
 
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -11,6 +11,7 @@
 
 namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
 
+use Brain\Monkey;
 use function KnowTheCode\ConfigStore\loadConfigFromFilesystem;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
@@ -33,7 +34,7 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 
 	/**
 	 * Test loadConfigFromFilesystem() should merge defaults with config
-	 *   and return store key.
+	 *   and return a store key.
 	 */
 	public function test_should_merge_defaults_and_return_store_key() {
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
@@ -48,8 +49,27 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	}
 
 	/**
-	 * Test for edge case #2.
+	 * Test loadConfigFromFilesystem() should store a config and return the store key.
 	 */
+	public function test_should_store_a_config_and_return_store_key() {
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
+		$defaults     = [];
+
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file, $defaults ) );
+	}
+
+	/**
+	 * Test loadConfigFromFilesystem() should return a fatal error when
+	 *  $path_to_file is invalid path.
+	 */
+	public function test_should_return_error_when_argument_is_invalid_path() {
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_load_config_from_filesystem' )
+			->once()
+			->with( 'path/to/file.php' )
+			->andThrow( 'Error' );
+		$this->expectException( \Error::class );
+		loadConfigFromFilesystem( 'path/to/file.php' );
+	}
 
 
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -77,11 +77,11 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 */
 	public function test_should_overwrite_store_and_return_store_key_from_file_config() {
 		Monkey\Functions\when( '\KnowTheCode\ConfigStore\_the_store' )
-			->justReturn( 'baz');
+			->justReturn( 'baz' );
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
 		loadConfigFromFilesystem( $path_to_file );
 
 		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
 	}
-
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -46,7 +46,7 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 			'ccc' => 'ddd',
 		];
 		$merged_config = [
-			'aaa' => 37,
+			'aaa' => 'bbb',
 			'ccc' => 'ddd',
 			'eee' => 'Coding is fun!',
 		];

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ *  Tests for external API function loadConfigFromFilesystem()
+ *
+ * @package    spiralWebDb\centralHub\Tests\Unit\ConfigStore
+ * @since      1.3.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
+
+use function KnowTheCode\ConfigStore\loadConfigFromFilesystem;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_LoadConfigFromFilesystem
+ *
+ * @package spiralWebDb\centralHub\Tests\Unit\ConfigStore
+ * @group   config-store
+ */
+class Tests_LoadConfigFromFilesystem extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/api.php';
+	}
+
+	/**
+	 * Test loadConfigFromFilesystem() should merge defaults with config
+	 *   and return store key.
+	 */
+	public function test_should_merge_defaults_and_return_store_key() {
+		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
+		$defaults     = [
+			'foo' => [
+				'aaa' => 37,
+				'eee' => 'Coding is fun!'
+			]
+		];
+
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file, $defaults ) );
+	}
+
+	/**
+	 * Test for edge case #2.
+	 */
+
+
+}

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -76,10 +76,8 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 *   return store key from file configuration.
 	 */
 	public function test_should_overwrite_store_and_return_store_key_from_file_config() {
-		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )
-			->once()
-			->with( 'baz', 'config_to_store' )
-			->andReturn( 'baz');
+		Monkey\Functions\when( '\KnowTheCode\ConfigStore\_the_store' )
+			->justReturn( 'baz');
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
 		loadConfigFromFilesystem( $path_to_file );
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -14,8 +14,6 @@ namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
 use Brain\Monkey;
 use function KnowTheCode\ConfigStore\loadConfigFromFilesystem;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
-use PHPUnit\Framework\Error\Notice;
-
 
 /**
  * Class Tests_LoadConfigFromFilesystem

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -72,15 +72,26 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	}
 
 	/**
-	 * Test loadConfigFromFilesystem() should overwrite stored configuration and
-	 *   return store key from file configuration.
+	 * Test loadConfigFromFilesystem() should overwrite stored configuration and return store key from
+	 * file configuration.
 	 */
 	public function test_should_overwrite_store_and_return_store_key_from_file_config() {
-		Monkey\Functions\when( '\KnowTheCode\ConfigStore\_the_store' )
-			->justReturn( 'baz' );
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
-		loadConfigFromFilesystem( $path_to_file );
+		$config = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd'
+		];
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_load_config_from_filesystem' )
+			->twice()
+			->with( $path_to_file )
+			->andReturn( [ 'foo', $config ] );
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_merge_with_defaults' )->never();
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )
+			->twice()
+			->with( 'foo', $config )
+			->andReturn( true );
 
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
 		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -55,9 +55,21 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 */
 	public function test_should_store_a_config_and_return_store_key() {
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
-		$defaults     = [];
+		$config = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd'
+		];
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_load_config_from_filesystem' )
+			->once()
+			->with( $path_to_file )
+			->andReturn( [ 'foo', $config ] );
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_merge_with_defaults' )->never();
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->with( 'foo', $config )
+			->andReturn( true );
 
-		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file, $defaults ) );
+		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -39,13 +39,32 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 *   and return a store key.
 	 */
 	public function test_should_merge_defaults_and_return_store_key() {
-		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
-		$defaults     = [
-			'foo' => [
-				'aaa' => 37,
-				'eee' => 'Coding is fun!'
-			]
+		$path_to_file  = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
+		$defaults      = [
+			'aaa' => 37,
+			'eee' => 'Coding is fun!',
 		];
+		$config        = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
+		];
+		$merged_config = [
+			'aaa' => 37,
+			'ccc' => 'ddd',
+			'eee' => 'Coding is fun!',
+		];
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_load_config_from_filesystem' )
+			->once()
+			->with( $path_to_file )
+			->andReturn( [ 'foo', $config ] );
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_merge_with_defaults' )
+			->once()
+			->with( $config, $defaults )
+			->andReturn( $merged_config );
+		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->with( 'foo', $merged_config )
+			->andReturn( true );
 
 		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file, $defaults ) );
 	}
@@ -55,9 +74,9 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 */
 	public function test_should_store_a_config_and_return_store_key() {
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
-		$config = [
+		$config       = [
 			'aaa' => 'bbb',
-			'ccc' => 'ddd'
+			'ccc' => 'ddd',
 		];
 		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_load_config_from_filesystem' )
 			->once()
@@ -78,9 +97,9 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 */
 	public function test_should_overwrite_store_and_return_store_key_from_file_config() {
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
-		$config = [
+		$config       = [
 			'aaa' => 'bbb',
-			'ccc' => 'ddd'
+			'ccc' => 'ddd',
 		];
 		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_load_config_from_filesystem' )
 			->twice()

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -14,6 +14,8 @@ namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
 use Brain\Monkey;
 use function KnowTheCode\ConfigStore\loadConfigFromFilesystem;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use PHPUnit\Framework\Error\Notice;
+
 
 /**
  * Class Tests_LoadConfigFromFilesystem
@@ -56,19 +58,6 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 		$defaults     = [];
 
 		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file, $defaults ) );
-	}
-
-	/**
-	 * Test loadConfigFromFilesystem() should return a fatal error when
-	 *  $path_to_file is invalid path.
-	 */
-	public function test_should_return_error_when_argument_is_invalid_path() {
-		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_load_config_from_filesystem' )
-			->once()
-			->with( 'path/to/file.php' )
-			->andThrow( 'Error' );
-		$this->expectException( \Error::class );
-		loadConfigFromFilesystem( 'path/to/file.php' );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -35,8 +35,7 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	}
 
 	/**
-	 * Test loadConfigFromFilesystem() should merge defaults with config
-	 *   and return a store key.
+	 * Test loadConfigFromFilesystem() should merge defaults with config and return a store key.
 	 */
 	public function test_should_merge_defaults_and_return_store_key() {
 		$path_to_file  = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
@@ -115,4 +114,3 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
 	}
 }
-


### PR DESCRIPTION
@hellofromtonya Hi Tonya! During spare moments this past week, I sat down and worked a bit on the project. I reviewed your comments for PR #20 and merged the `development` branch into my local version of `add/loadConfigFromFS)`. 

My latest set of commits address edge case #6; 

>With a valid path to the config file, a configuration array that contains a key paired to an empty or null value, and an array of defaults, I expect the API function `loadConfigFromFilesystem` to provide a $store_key and a $config assigned a value of `false`. The internal API function `_the_store()` would throw an Exception error.

Well, I changed the first conditional in `_the_store()` to return an Exception rather than an empty array stored in `$config_store`. 

Something interesting happened when I attempted to log in and visit the site Admin page. `_the_store()` threw an Exception! According to the stack track presented by Whoops!, when the site starts up and calls the API function `getAllKeysStartingWith( $starts_with )`, there's no meta_key configuration stored in `_the_store`. So instead of returning an empty array, we're now throwing an Exception. 

The Exception can be avoided by adding an `! is_admin` conditional tag to the first conditional in `_the_store()`. While that will display the site Admin, the unit tests for `_theStore` no longer pass. ;-(

Your thoughts? 
