### PR TITLE
PR #22 (modify/loadConfigFromFS)

### DIFF
--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfigFromFilesystem.php
@@ -62,22 +62,6 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 	 * Test loadConfigFromFilesystem() should overwrite stored configuration and return store key from
 	 * file configuration.
 	 */
-	public function test_should_overwrite_store_and_return_store_key_from_file_config() {
-		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
-		$config       = [
-			'aaa' => 'bbb',
-			'ccc' => 'ddd',
-		];
-
-		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
-		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
-		$this->assertSame( $config, _the_store( 'foo' ) );
-	}
-
-	/**
-	 * Test loadConfigFromFilesystem() should overwrite stored configuration and return store key from
-	 * file configuration.
-	 */
 	public function test_should_throw_exception_when_no_store_key() {
 		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/config-with-params-only.php';
 		$this->expectException( \Exception::class );
@@ -108,3 +92,4 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 		loadConfigFromFilesystem( $path_to_file );
 	}
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
@@ -12,6 +12,7 @@
 namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
 
 use function KnowTheCode\ConfigStore\_the_store;
+use function KnowTheCode\ConfigStore\getConfig;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
 /**
@@ -29,6 +30,7 @@ class Tests_TheStore extends Test_Case {
 		parent::setUp();
 
 		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/internals.php';
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/api.php';
 	}
 
 	/**
@@ -118,6 +120,7 @@ class Tests_TheStore extends Test_Case {
 		];
 
 		$this->assertTrue( _the_store( 'foo', $config ) );
+		$this->assertSame( $config, getConfig( 'foo' ) );
 
 		$new_config = [
 			'aaa' => 37,
@@ -126,6 +129,7 @@ class Tests_TheStore extends Test_Case {
 		];
 
 		$this->assertTrue( _the_store( 'foo', $new_config ) );
+		$this->assertSame( $new_config, getConfig( 'foo' ) );
 	}
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
@@ -107,4 +107,25 @@ class Tests_TheStore extends Test_Case {
 		// Clean up.
 		_the_store( __METHOD__, null, true );
 	}
+
+	/**
+	 *  Test _the_store() should overwrite a stored config using the same key.
+	 */
+	public function test_should_overwrite_a_stored_config_using_same_key() {
+		$config = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd'
+		];
+
+		$this->assertTrue( _the_store( 'foo', $config ) );
+
+		$new_config = [
+			'aaa' => 37,
+			'ccc' => 'Coding is fun!',
+			'eee' => 'WordPress rocks!',
+		];
+
+		$this->assertTrue( _the_store( 'foo', $new_config ) );
+	}
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfigFromFilesystem.php
@@ -87,28 +87,5 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 
 		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
 	}
-
-	/**
-	 * Test loadConfigFromFilesystem() should overwrite stored configuration and return store key from
-	 * file configuration.
-	 */
-	public function test_should_overwrite_store_and_return_store_key_from_file_config() {
-		$path_to_file = CENTRAL_HUB_ROOT_DIR . '/tests/phpunit/fixtures/test-cpt-config.php';
-		$config       = [
-			'aaa' => 'bbb',
-			'ccc' => 'ddd',
-		];
-		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_load_config_from_filesystem' )
-			->twice()
-			->with( $path_to_file )
-			->andReturn( [ 'foo', $config ] );
-		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_merge_with_defaults' )->never();
-		Monkey\Functions\expect( '\KnowTheCode\ConfigStore\_the_store' )
-			->twice()
-			->with( 'foo', $config )
-			->andReturn( true );
-
-		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
-		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
-	}
 }
+


### PR DESCRIPTION
@hellofromtonya Following our conversation earlier today (07/02/19), I wrote a new unit test for `_the_store()` to test that a new config assigned to the same store key will overwrite the initial (existing) config. The edge cases for the unit & integration test of `loadConfigFromFilesystem` that will never occur were both removed. 