### PR TITLE
PR #23 (add/loadConfig)

### DIFF
--- a/mu-plugins/central-hub/src/config-store/api.php
+++ b/mu-plugins/central-hub/src/config-store/api.php
@@ -90,7 +90,7 @@ function loadConfigFromFilesystem( $path_to_file, array $defaults = array() ) {
  * @param mixed  $config    Runtime configuration parameter(s)
  */
 function loadConfig( $store_key, $config ) {
-	_the_store( $store_key, $config );
+	return _the_store( $store_key, $config );
 }
 
 /**

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
@@ -44,17 +44,18 @@ class Tests_LoadConfig extends Test_Case {
 		_the_store( __METHOD__, null, true );
 	}
 
-
 	/**
-	 * Test loadConfig() should throw an Exception and message when given an empty store_key and valid config.
+	 * Test loadConfig() should throw an error when no store key is given with a config to store.
 	 */
-	public function test_should_throw_exception_when_given_empty_key_and_valid_config() {
-		// Failed asserting that exception of type "Exception" is thrown.
+	public function test_should_throw_error_when_no_store_key_given_with_config_to_store() {
 		$config  = [
 			'aaa' => 'bbb',
 			'ccc' => 'ddd',
 		];
-		$message = "Configuration for [''] does not exist in the ConfigStore";
+		$message = sprintf(
+			'Unable to store as no store key was given with the configuration to store: %s',
+			print_r( $config, true )
+		);
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( $message );
 		loadConfig( '', $config );

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
@@ -11,6 +11,7 @@
 
 namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
 
+use function KnowTheCode\ConfigStore\loadConfig;
 use function KnowTheCode\ConfigStore\_the_store;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 
@@ -32,6 +33,43 @@ class Tests_LoadConfig extends Test_Case {
 		];
 		$this->assertTrue( loadConfig( 'foo', $config ) );
 
+		$config = [
+			'aaa' => 37,
+			'ccc' => 'Coding is fun!',
+			'eee' => 'WordPress rocks!',
+		];
+		$this->assertTrue( loadConfig( __METHOD__, $config ) );
 
+		// Clean up _the_store.
+		_the_store( __METHOD__, null, true );
+	}
+
+
+	/**
+	 * Test loadConfig() should throw an Exception and message when given an empty store_key and valid config.
+	 */
+	public function test_should_throw_exception_when_given_empty_key_and_valid_config() {
+		// Failed asserting that exception of type "Exception" is thrown.
+		$config  = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
+		];
+		$message = "Configuration for [''] does not exist in the ConfigStore";
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( $message );
+		loadConfig( '', $config );
+	}
+
+	/**
+	 * Test loadConfig() should throw an Exception and message when given a valid store key and empty config.
+	 */
+	public function test_should_throw_exception_when_given_valid_key_and_empty_config() {
+		// Failed asserting that exception of type "Exception" is thrown.
+		$config  = [];
+		$message = "Configuration for [foo] does not exist in the ConfigStore";
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( $message );
+		loadConfig( 'foo', $config );
 	}
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *  Tests for external API function loadConfig()
+ *
+ * @package    spiralWebDb\centralHub\Tests\Integration\ConfigStore
+ * @since      1.3.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
+
+use function KnowTheCode\ConfigStore\_the_store;
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+
+/**
+ * Class Tests_LoadConfig
+ *
+ * @package spiralWebDb\centralHub\Tests\Integration\ConfigStore
+ * @group   config-store
+ */
+class Tests_LoadConfig extends Test_Case {
+
+	/**
+	 * Test loadConfig() should store a config given a valid store key and config.
+	 */
+	public function test_should_store_config_in_the_store_given_valid_key_and_config() {
+		$config = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
+		];
+		$this->assertTrue( loadConfig( 'foo', $config ) );
+
+
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
@@ -65,12 +65,9 @@ class Tests_LoadConfig extends Test_Case {
 	 * Test loadConfig() should throw an Exception and message when given a valid store key and empty config.
 	 */
 	public function test_should_throw_exception_when_given_valid_key_and_empty_config() {
-		// Failed asserting that exception of type "Exception" is thrown.
-		$config  = [];
-		$message = "Configuration for [foo] does not exist in the ConfigStore";
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( $message );
-		loadConfig( 'foo', $config );
+		$this->expectExceptionMessage( sprintf( 'Configuration for [%s] does not exist in the ConfigStore', __METHOD__ ) );
+		loadConfig( __METHOD__, [] );
 	}
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
@@ -41,6 +41,7 @@ class Tests_LoadConfig extends Test_Case {
 		$this->assertTrue( loadConfig( __METHOD__, $config ) );
 
 		// Clean up _the_store.
+		_the_store( 'foo', null, true );
 		_the_store( __METHOD__, null, true );
 	}
 
@@ -70,4 +71,3 @@ class Tests_LoadConfig extends Test_Case {
 		loadConfig( __METHOD__, [] );
 	}
 }
-

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -55,9 +55,9 @@ class Tests_LoadConfig extends Test_Case {
 		];
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
 			->once()
-			->with( '__METHOD__', $config )
+			->with( __METHOD__, $config )
 			->andReturn( true );
-		$this->assertTrue( loadConfig( '__METHOD__', $config ) );
+		$this->assertTrue( loadConfig( __METHOD__, $config ) );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -16,7 +16,7 @@ use function KnowTheCode\ConfigStore\loadConfig;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
 /**
- * Class Tests_LoadConfigFromFilesystem
+ * Class Tests_LoadConfig
  *
  * @package spiralWebDb\centralHub\Tests\Unit\ConfigStore
  * @group   config-store
@@ -30,4 +30,24 @@ class Tests_LoadConfig extends Test_Case {
 		parent::setUp();
 
 		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/api.php';
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/internals.php';
 	}
+
+	/**
+	 * Test loadConfig() should store a config given a valid store key and config.
+	 */
+	public function test_should_store_config_in_the_store_given_valid_key_and_config() {
+		$config = [
+			'foo' => [
+				'aaa' => 'bbb',
+				'ccc' => 'ddd',
+			]
+		];
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->with( 'foo', $config )
+			->andReturn( true );
+
+		$this->assertTrue( loadConfig( 'foo', $config ) );
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -66,7 +66,10 @@ class Tests_LoadConfig extends Test_Case {
 			'aaa' => 'bbb',
 			'ccc' => 'ddd',
 		];
-		$message = "Configuration for [''] does not exist in the ConfigStore";
+		$message = sprintf(
+			'Unable to store as no store key was given with the configuration to store: %s',
+			print_r( $config, true )
+		);
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
 			->once()
 			->with( '', $config )

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ *  Tests for external API function loadConfig()
+ *
+ * @package    spiralWebDb\centralHub\Tests\Unit\ConfigStore
+ * @since      1.3.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
+
+use Brain\Monkey;
+use function KnowTheCode\ConfigStore\loadConfig;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_LoadConfigFromFilesystem
+ *
+ * @package spiralWebDb\centralHub\Tests\Unit\ConfigStore
+ * @group   config-store
+ */
+class Tests_LoadConfig extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/api.php';
+	}

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -30,7 +30,6 @@ class Tests_LoadConfig extends Test_Case {
 		parent::setUp();
 
 		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/api.php';
-		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/internals.php';
 	}
 
 	/**
@@ -61,9 +60,9 @@ class Tests_LoadConfig extends Test_Case {
 	}
 
 	/**
-	 * Test loadConfig() should throw an Exception error given empty store_key and valid config.
+	 * Test loadConfig() should throw an Exception and message when given an empty store_key and valid config.
 	 */
-	public function test_should_throw_exception_when_store_key_is_empty() {
+	public function test_should_throw_exception_when_given_empty_key_and_valid_config() {
 		$config  = [
 			'aaa' => 'bbb',
 			'ccc' => 'ddd',
@@ -76,6 +75,21 @@ class Tests_LoadConfig extends Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( $message );
 		loadConfig( '', $config );
+	}
+
+	/**
+	 * Test loadConfig() should throw an Exception and message when given a valid store key and empty config.
+	 */
+	public function test_should_throw_exception_when_given_valid_key_and_empty_config() {
+		$config = [];
+		$message = "Configuration for [foo] does not exist in the ConfigStore";
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->with( 'foo', $config )
+			->andThrow( new \Exception( $message ) );
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( $message );
+		loadConfig( 'foo', $config );
 	}
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -38,10 +38,8 @@ class Tests_LoadConfig extends Test_Case {
 	 */
 	public function test_should_store_config_in_the_store_given_valid_key_and_config() {
 		$config = [
-			'foo' => [
-				'aaa' => 'bbb',
-				'ccc' => 'ddd',
-			]
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
 		];
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
 			->once()
@@ -49,5 +47,16 @@ class Tests_LoadConfig extends Test_Case {
 			->andReturn( true );
 
 		$this->assertTrue( loadConfig( 'foo', $config ) );
+
+		$config = [
+			'aaa' => 37,
+			'ccc' => 'Coding is fun!',
+			'eee' => 'WordPress rocks!',
+		];
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->with( '__METHOD__', $config )
+			->andReturn( true );
+		$this->assertTrue( loadConfig( '__METHOD__', $config ) );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -44,7 +44,6 @@ class Tests_LoadConfig extends Test_Case {
 			->once()
 			->with( 'foo', $config )
 			->andReturn( true );
-
 		$this->assertTrue( loadConfig( 'foo', $config ) );
 
 		$config = [

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -64,23 +64,18 @@ class Tests_LoadConfig extends Test_Case {
 	 * Test loadConfig() should throw an Exception error given empty store_key and valid config.
 	 */
 	public function test_should_throw_exception_when_store_key_is_empty() {
-		$store_key = '';
-		$config = [
-			[
-				'aaa' => 'bbb',
-				'ccc' => 'ddd',
-			]
+		$config  = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
 		];
+		$message = "Configuration for [''] does not exist in the ConfigStore";
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
 			->once()
 			->with( '', $config )
-			->andThrow( 'Exception' );
+			->andThrow( new \Exception( $message ) );
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage(
-			sprintf(
-				'Configuration for [\'\'] does not exist in the ConfigStore', '' )
-		);
-		loadConfig( '', $config);
+		$this->expectExceptionMessage( $message );
+		loadConfig( '', $config );
 	}
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/loadConfig.php
@@ -59,4 +59,28 @@ class Tests_LoadConfig extends Test_Case {
 			->andReturn( true );
 		$this->assertTrue( loadConfig( '__METHOD__', $config ) );
 	}
+
+	/**
+	 * Test loadConfig() should throw an Exception error given empty store_key and valid config.
+	 */
+	public function test_should_throw_exception_when_store_key_is_empty() {
+		$store_key = '';
+		$config = [
+			[
+				'aaa' => 'bbb',
+				'ccc' => 'ddd',
+			]
+		];
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->with( '', $config )
+			->andThrow( 'Exception' );
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage(
+			sprintf(
+				'Configuration for [\'\'] does not exist in the ConfigStore', '' )
+		);
+		loadConfig( '', $config);
+	}
 }
+


### PR DESCRIPTION
@hellofromtonya I'm scratching my head. When I call the assert in the test method `test_should_store_config_in_the_store_given_valid_key_and_config`, the API function `loadConfig` returns the error message: 

>Failed asserting that null is identical to 'foo'.

When I use `var_dump()` to inspect `$config`, and `_the_store()` in the test method, I get a value back. But when I inspect `loadConfig( $store_key, $config )`, `var_dump()` returns a value of NULL. 

Why does `loadConfig()` return a value of NULL when I pass the function it's expected parameters? 