### PR TITLE
[WIP] PR #24 (add/getAllKeys)

### DIFF
--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllKeys.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for the API function getAllKeys().
+ *
+ * @package     spiralWebDb\centralHub\Tests\Integration\ConfigStore
+ * @since       1.3.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
+
+use function KnowTheCode\ConfigStore\_the_store;
+use function KnowTheCode\ConfigStore\loadConfig;
+use function KnowTheCode\ConfigStore\getAllKeys;
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+
+/**
+ * Class Tests_GetAllKeys
+ *
+ * @package spiralWebDb\centralHub\Tests\Integration\ConfigStore
+ * @group   config-store
+ */
+class Tests_GetAllKeys extends Test_Case {
+
+	/**
+	 * Test getAllKeys() should return all store keys.
+	 */
+	public function test_should_return_all_store_keys() {
+		// Intialize _the_store and unset all previously stored data.
+		$configs = _the_store();
+		if ( empty( $configs ) ) {
+			return;
+		}
+		foreach ( array_keys( $configs ) as $store_key ) {
+			_the_store( $store_key, null, true );
+		}
+		$config_store = [
+			'foo' => [
+				'aaa' => 37,
+				'ccc' => 'Coding is fun!',
+				'eee' => 'WordPress rocks!',
+			],
+			'bar' => [
+				'bbb' => 'Hello World',
+			],
+			'baz' => [
+				'ddd' => 'Brain Monkey',
+			],
+		];
+		foreach ( $config_store as $store_key => $config_to_store ) {
+			loadConfig( $store_key, $config_to_store );
+		}
+		$this->assertSame( [ 'foo', 'bar', 'baz' ], getAllKeys() );
+
+		// Clean _the_store in preparation for the next test.
+		$configs = _the_store();
+		foreach ( $configs as $store_key => $config_to_store ) {
+			_the_store( $store_key, null, true );
+		}
+	}
+
+}

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllKeys.php
@@ -61,4 +61,12 @@ class Tests_GetAllKeys extends Test_Case {
 		}
 	}
 
+	/**
+	 * Test getAllKeys() should return an empty array when store is empty.
+	 */
+	public function test_should_return_empty_array_when_store_is_empty() {
+		$expected = [];
+		$this->assertSame( $expected, getAllKeys() );
+	}
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllKeys.php
@@ -25,17 +25,24 @@ use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 class Tests_GetAllKeys extends Test_Case {
 
 	/**
-	 * Test getAllKeys() should return all store keys.
+	 * Empty the store before starting these tests.
 	 */
-	public function test_should_return_all_store_keys() {
-		// Intialize _the_store and unset all previously stored data.
+	public static function setUpBeforeClass() {
 		$configs = _the_store();
 		if ( empty( $configs ) ) {
 			return;
 		}
+
 		foreach ( array_keys( $configs ) as $store_key ) {
 			_the_store( $store_key, null, true );
 		}
+	}
+
+	/**
+	 * Test getAllKeys() should return all store keys.
+	 */
+	public function test_should_return_all_store_keys() {
+		// Initialize with known keys and configs.
 		$config_store = [
 			'foo' => [
 				'aaa' => 37,
@@ -52,11 +59,12 @@ class Tests_GetAllKeys extends Test_Case {
 		foreach ( $config_store as $store_key => $config_to_store ) {
 			loadConfig( $store_key, $config_to_store );
 		}
+
+		// Get the keys and test.
 		$this->assertSame( [ 'foo', 'bar', 'baz' ], getAllKeys() );
 
-		// Clean _the_store in preparation for the next test.
-		$configs = _the_store();
-		foreach ( $configs as $store_key => $config_to_store ) {
+		// Remove the configurations added in this test from the store.
+		foreach ( $config_store as $store_key => $config_to_store ) {
 			_the_store( $store_key, null, true );
 		}
 	}

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeys.php
@@ -34,21 +34,26 @@ class Tests_GetAllKeys extends Test_Case {
 	}
 
 	/**
-	 * Test getAllKeys() should return the array keys from `_the_store()`.
+	 * Test getAllKeys() should return all store keys.
 	 */
-	public function test_should_return_the_array_keys_from_the_store() {
-		// array_keys() expects parameter 1 to be array, null given
-		$config = [
-			'aaa' => 37,
-			'ccc' => 'Coding is fun!',
-			'eee' => 'WordPress rocks!',
+	public function test_should_return_all_store_keys() {
+		$config_store = [
+			'foo' => [
+				'aaa' => 37,
+				'ccc' => 'Coding is fun!',
+				'eee' => 'WordPress rocks!',
+			],
+			'bar' => [
+				'bbb' => 'Hello World',
+			],
+			'baz' => [
+				'ddd' => 'Brain Monkey',
+			],
 		];
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
 			->once()
-			->with( 'foo', $config )
-			->andReturnValues( [ 'foo' ] );
-		$this->assertArrayHasKey( 'foo', getAllKeys() );
-		$this->assertSame( 'foo', getAllKeys() );
+			->withNoArgs()
+			->andReturn( $config_store );
+		$this->assertSame( [ 'foo', 'bar', 'baz' ], getAllKeys() );
 	}
 }
-

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeys.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ *  Tests for getAllKeys()
+ *
+ * @package    spiralWebDb\centralHub\Tests\Unit\ConfigStore
+ * @since      1.3.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
+
+use Brain\Monkey;
+use function KnowTheCode\ConfigStore\getAllKeys;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_GetAllKeys
+ *
+ * @package spiralWebDb\centralHub\Tests\Unit\ConfigStore
+ * @group   config-store
+ */
+class Tests_GetAllKeys extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/internals.php';
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/api.php';
+	}
+
+	/**
+	 * Test getAllKeys() should return the array keys from `_the_store()`.
+	 */
+	public function test_should_return_the_array_keys_from_the_store() {
+		// array_keys() expects parameter 1 to be array, null given
+		$config = [
+			'aaa' => 37,
+			'ccc' => 'Coding is fun!',
+			'eee' => 'WordPress rocks!',
+		];
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->with( 'foo', $config )
+			->andReturnValues( [ 'foo' ] );
+		$this->assertArrayHasKey( 'foo', getAllKeys() );
+		$this->assertSame( 'foo', getAllKeys() );
+	}
+}
+

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeys.php
@@ -56,4 +56,15 @@ class Tests_GetAllKeys extends Test_Case {
 			->andReturn( $config_store );
 		$this->assertSame( [ 'foo', 'bar', 'baz' ], getAllKeys() );
 	}
+
+	/**
+	 * Test getAllKeys() should return an empty array when store is empty.
+	 */
+	public function test_should_return_empty_array_when_store_is_empty() {
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\_the_store' )
+			->once()
+			->withNoArgs()
+			->andReturn( [] );
+		$this->assertSame( [], getAllKeys() );
+	}
 }


### PR DESCRIPTION
@hellofromtonya Hi Tonya, I decided to get started on the unit tests for this API function as it's relatively short. I ran into a new situation I've not encountered before. I want to use BrainMonkey to mock the PHP function `array_keys` which accepts the internal API function `_the_store` as an argument. 

I received the following error message on the CLI: 

>Patchwork\Exceptions\NotUserDefined: Please include {"redefinable-internals": ["array_keys"]} in your patchwork.json.

When I searched for the `patchwork.json` file in the `wp-content/tests/vendor/antecendent/patchwork` directory, I couldn't find a `patchwork.json` file. [I did find the source of the error message in an `Exceptions.php` file within Patchwork.]

My expectation for this test is: 

>Test getAllKeys() should return the array_keys from `_the_store` when keys are stored. 

This is also the first time I am using BM's `->justReturnValues` construct with an `expect()` method. Please let me know if I've set it up and am using it correctly. 