### PR TITLE
Improved and added edge case to `_the_store()`

### DIFF
--- a/mu-plugins/central-hub/src/config-store/internals.php
+++ b/mu-plugins/central-hub/src/config-store/internals.php
@@ -26,8 +26,8 @@ namespace KnowTheCode\ConfigStore;
 function _the_store( $store_key = '', $config_to_store = array(), $remove = null ) {
 	static $config_store = array();
 
-	// Bail out if no store key is given.
-	if ( ! $store_key ) {
+	// Return all stored configurations when no store key or config to store is given.
+	if ( empty( $store_key ) and empty( $config_to_store ) ) {
 		return $config_store;
 	}
 

--- a/mu-plugins/central-hub/src/config-store/internals.php
+++ b/mu-plugins/central-hub/src/config-store/internals.php
@@ -26,9 +26,18 @@ namespace KnowTheCode\ConfigStore;
 function _the_store( $store_key = '', $config_to_store = array(), $remove = null ) {
 	static $config_store = array();
 
-	// Return all stored configurations when no store key or config to store is given.
-	if ( empty( $store_key ) and empty( $config_to_store ) ) {
-		return $config_store;
+	if ( empty( $store_key ) ) {
+		// Return all stored configurations when no store key or config to store is given.
+		if ( empty( $config_to_store ) ) {
+			return $config_store;
+		}
+		
+		throw new \Exception(
+			sprintf(
+				'Unable to store as no store key was given with the configuration to store: %s',
+				print_r( $config_to_store, true )
+			)
+		);
 	}
 
 	// Store the given configuration.
@@ -69,7 +78,7 @@ function _the_store( $store_key = '', $config_to_store = array(), $remove = null
  * @throws \Exception
  */
 function _load_config_from_filesystem( $path_to_file ) {
-	$config    = (array) require $path_to_file;
+	$config = (array) require $path_to_file;
 
 	$store_key = key( $config );
 	if ( empty( $store_key ) ) {

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
@@ -115,6 +115,23 @@ class Tests_TheStore extends Test_Case {
 	}
 
 	/**
+	 * Test _the_store() should throw an error when no store key is given with a config to store.
+	 */
+	public function test_should_throw_error_when_no_store_key_given_with_config_to_store() {
+		$config  = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
+		];
+		$message = sprintf(
+			'Unable to store as no store key was given with the configuration to store: %s',
+			print_r( $config, true )
+		);
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( $message );
+		_the_store( '', $config );
+	}
+
+	/**
 	 * Test _the_store() should throw an error when the store key does not exist in the store.
 	 */
 	public function test_should_throw_error_when_store_key_does_not_exist() {

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
@@ -116,7 +116,7 @@ class Tests_TheStore extends Test_Case {
 	public function test_should_overwrite_a_stored_config_using_same_key() {
 		$config = [
 			'aaa' => 'bbb',
-			'ccc' => 'ddd'
+			'ccc' => 'ddd',
 		];
 
 		$this->assertTrue( _the_store( 'foo', $config ) );
@@ -131,5 +131,33 @@ class Tests_TheStore extends Test_Case {
 		$this->assertTrue( _the_store( 'foo', $new_config ) );
 		$this->assertSame( $new_config, getConfig( 'foo' ) );
 	}
-}
 
+	/**
+	 * Test _the_store() should return all stored configs when no store key or configuration is provided.
+	 */
+	public function test_should_return_all_stored_configs_when_no_key_or_configs() {
+		// Store some configurations.
+		$configs = [
+			'foo' => [
+				'aaa' => 37,
+			],
+			'bar' => [
+				'bbb' => 'Hello World',
+			],
+			'baz' => [
+				'ccc' => 'Testing the store.',
+			],
+		];
+		foreach ( $configs as $store_key => $config ) {
+			_the_store( $store_key, $config );
+		}
+
+		// Should return the all stored configs.
+		$this->assertSame( $configs, _the_store() );
+
+		// Clean up.
+		foreach ( array_keys( $configs ) as $store_key ) {
+			_the_store( $store_key, [], true );
+		}
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
@@ -110,7 +110,7 @@ class Tests_TheStore extends Test_Case {
 			return;
 		}
 		foreach ( array_keys( $configs ) as $store_key ) {
-			_the_store( $store_key );
+			_the_store( $store_key, null, true );
 		}
 	}
 
@@ -179,5 +179,8 @@ class Tests_TheStore extends Test_Case {
 
 		$this->assertTrue( _the_store( 'foo', $new_config ) );
 		$this->assertSame( $new_config, getConfig( 'foo' ) );
+
+		// Clean up.
+		_the_store( 'foo', null, true );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
@@ -82,7 +82,7 @@ class Tests_TheStore extends Test_Case {
 			'ccc' => 'ddd',
 		];
 
-		$this->assertTrue( _the_store( 'foo', $config ) );
+		$this->assertTrue( _the_store( __METHOD__, $config ) );
 	}
 
 	/**
@@ -94,15 +94,15 @@ class Tests_TheStore extends Test_Case {
 			'aaa' => 'bbb',
 			'ccc' => 'ddd',
 		];
-		$this->assertTrue( _the_store( 'remove_key', $config ) );
+		$this->assertTrue( _the_store( __METHOD__, $config ) );
 
 		// Remove it. Check true is returned.
-		$this->assertTrue( _the_store( 'remove_key', null, true ) );
+		$this->assertTrue( _the_store( __METHOD__, null, true ) );
 
-		// Check that 'remove_key' no longer exists in the store.
+		// Check that __METHOD__ store key no longer exists in the store.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Configuration for [remove_key] does not exist in the ConfigStore' );
-		_the_store( 'remove_key' );
+		$this->expectExceptionMessage( sprintf( 'Configuration for [%s] does not exist in the ConfigStore', __METHOD__ ) );
+		_the_store( __METHOD__ );
 
 		// Empty the store from previous tests.  We waited to clean up here to ensure all functionality works.
 		$configs = _the_store();
@@ -168,8 +168,8 @@ class Tests_TheStore extends Test_Case {
 			'ccc' => 'ddd',
 		];
 
-		$this->assertTrue( _the_store( 'foo', $config ) );
-		$this->assertSame( $config, getConfig( 'foo' ) );
+		$this->assertTrue( _the_store( __METHOD__, $config ) );
+		$this->assertSame( $config, getConfig( __METHOD__ ) );
 
 		$new_config = [
 			'aaa' => 37,
@@ -177,10 +177,10 @@ class Tests_TheStore extends Test_Case {
 			'eee' => 'WordPress rocks!',
 		];
 
-		$this->assertTrue( _the_store( 'foo', $new_config ) );
-		$this->assertSame( $new_config, getConfig( 'foo' ) );
+		$this->assertTrue( _the_store( __METHOD__, $new_config ) );
+		$this->assertSame( $new_config, getConfig( __METHOD__ ) );
 
 		// Clean up.
-		_the_store( 'foo', null, true );
+		_the_store( __METHOD__, null, true );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
@@ -49,6 +49,30 @@ class Tests_TheStore extends Test_Case {
 		$this->assertSame( $expected, _the_store( '0' ) );
 	}
 
+	/**
+	 * Test _the_store() should return all stored configs when no store key or configuration is provided.
+	 */
+	public function test_should_return_all_stored_configs_when_no_key_or_configs() {
+		// Store some configurations.
+		$configs = [
+			'foo' => [
+				'aaa' => 37,
+			],
+			'bar' => [
+				'bbb' => 'Hello World',
+			],
+			'baz' => [
+				'ccc' => 'Testing the store.',
+			],
+		];
+		foreach ( $configs as $store_key => $config ) {
+			_the_store( $store_key, $config );
+		}
+
+		// Should return the all stored configs.
+		$this->assertSame( $configs, _the_store() );
+	}
+
 	/*
 	 * Test _the_store() should return true when a configuration is stored.
 	 */
@@ -62,33 +86,41 @@ class Tests_TheStore extends Test_Case {
 	}
 
 	/**
+	 * Test _the_store() should remove the config when the store key exists.
+	 */
+	public function test_should_remove_config_when_store_key_exists() {
+		// Set up by adding a configuration into the store.
+		$config = [
+			'aaa' => 'bbb',
+			'ccc' => 'ddd',
+		];
+		_the_store( __METHOD__, $config );
+
+		// Remove it. Check true is returned.
+		$this->assertTrue( _the_store( __METHOD__, null, true ) );
+
+		// Check that 'foo' no longer exists in the store.
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Configuration for [foo] does not exist in the ConfigStore' );
+		_the_store( __METHOD__ );
+
+		// Empty the store from previous tests.  We waited to clean up here to ensure all functionality works.
+		$configs = _the_store();
+		if ( empty( $configs ) ) {
+			return;
+		}
+		foreach ( array_keys( $configs ) as $store_key ) {
+			_the_store( $store_key );
+		}
+	}
+
+	/**
 	 * Test _the_store() should throw an error when the store key does not exist in the store.
 	 */
 	public function test_should_throw_error_when_store_key_does_not_exist() {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Configuration for [invalid_store_key] does not exist in the ConfigStore' );
 		_the_store( 'invalid_store_key' );
-	}
-
-	/**
-	 * Test _the_store() should remove the config when the store key exists.
-	 */
-	public function test_should_remove_config_when_store_key_exists() {
-		$config = [
-			'aaa' => 'bbb',
-			'ccc' => 'ddd',
-		];
-
-		// Make sure the config exists in the store.
-		$this->assertSame( $config, _the_store( 'foo' ) );
-
-		// Remove it. Check true is returned.
-		$this->assertTrue( _the_store( 'foo', null, true ) );
-
-		// Check that 'foo' no longer exists in the store.
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Configuration for [foo] does not exist in the ConfigStore' );
-		_the_store( 'foo' );
 	}
 
 	/*
@@ -130,34 +162,5 @@ class Tests_TheStore extends Test_Case {
 
 		$this->assertTrue( _the_store( 'foo', $new_config ) );
 		$this->assertSame( $new_config, getConfig( 'foo' ) );
-	}
-
-	/**
-	 * Test _the_store() should return all stored configs when no store key or configuration is provided.
-	 */
-	public function test_should_return_all_stored_configs_when_no_key_or_configs() {
-		// Store some configurations.
-		$configs = [
-			'foo' => [
-				'aaa' => 37,
-			],
-			'bar' => [
-				'bbb' => 'Hello World',
-			],
-			'baz' => [
-				'ccc' => 'Testing the store.',
-			],
-		];
-		foreach ( $configs as $store_key => $config ) {
-			_the_store( $store_key, $config );
-		}
-
-		// Should return the all stored configs.
-		$this->assertSame( $configs, _the_store() );
-
-		// Clean up.
-		foreach ( array_keys( $configs ) as $store_key ) {
-			_the_store( $store_key, [], true );
-		}
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/_theStore.php
@@ -94,15 +94,15 @@ class Tests_TheStore extends Test_Case {
 			'aaa' => 'bbb',
 			'ccc' => 'ddd',
 		];
-		_the_store( __METHOD__, $config );
+		$this->assertTrue( _the_store( 'remove_key', $config ) );
 
 		// Remove it. Check true is returned.
-		$this->assertTrue( _the_store( __METHOD__, null, true ) );
+		$this->assertTrue( _the_store( 'remove_key', null, true ) );
 
-		// Check that 'foo' no longer exists in the store.
+		// Check that 'remove_key' no longer exists in the store.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Configuration for [foo] does not exist in the ConfigStore' );
-		_the_store( __METHOD__ );
+		$this->expectExceptionMessage( 'Configuration for [remove_key] does not exist in the ConfigStore' );
+		_the_store( 'remove_key' );
 
 		// Empty the store from previous tests.  We waited to clean up here to ensure all functionality works.
 		$configs = _the_store();


### PR DESCRIPTION
1. Improved the request for all of the configs stored by checking that the store key and config are not passed into the function.  Note:  This request is required by the API function `getAllKeys()`.
2. Added an error for when a store key is not given but a configuration to store is.
3. Improved the tests.