### PR TITLE
PR#26 (add/getAllKeysStartingWith)

### DIFF
--- a/mu-plugins/central-hub/src/config-store/api.php
+++ b/mu-plugins/central-hub/src/config-store/api.php
@@ -118,11 +118,6 @@ function getAllKeys() {
  * @return array
  */
 function getAllKeysStartingWith( $starts_with ) {
-
-//	return array_filter( getAllKeys(), function ( $key ) use ( $starts_with ) {
-//		return str_starts_with( $key, $starts_with );
-//	} );
-
 	$filtered_keys = array();
 
 	foreach ( getAllKeys() as $key ) {

--- a/mu-plugins/central-hub/src/config-store/api.php
+++ b/mu-plugins/central-hub/src/config-store/api.php
@@ -119,10 +119,9 @@ function getAllKeys() {
  */
 function getAllKeysStartingWith( $starts_with ) {
 
-	return array_filter( getAllKeys(), function ( $key ) use ( $starts_with ) {
-		return str_starts_with( $key, $starts_with );
-	} );
-
+//	return array_filter( getAllKeys(), function ( $key ) use ( $starts_with ) {
+//		return str_starts_with( $key, $starts_with );
+//	} );
 
 	$filtered_keys = array();
 

--- a/mu-plugins/central-hub/src/config-store/api.php
+++ b/mu-plugins/central-hub/src/config-store/api.php
@@ -126,11 +126,5 @@ function getAllKeysStartingWith( $starts_with ) {
 		}
 	}
 
-	if ( empty( $filtered_keys ) ) {
-		throw new \InvalidArgumentException(
-			sprintf( 'None of the searched keys start with the selected string: %s', $starts_with )
-		);
-	}
-
 	return $filtered_keys;
 }

--- a/mu-plugins/central-hub/src/config-store/api.php
+++ b/mu-plugins/central-hub/src/config-store/api.php
@@ -126,5 +126,11 @@ function getAllKeysStartingWith( $starts_with ) {
 		}
 	}
 
+	if ( empty( $filtered_keys ) ) {
+		throw new \InvalidArgumentException(
+			sprintf( 'None of the searched keys start with the selected string: %s', $starts_with )
+		);
+	}
+
 	return $filtered_keys;
 }

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -70,24 +70,21 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 	}
 
 	/**
-	 * Test getAllKeysStartingWith() should throw an Exception when filtered keys do not start with a given string.
+	 * Test getAllKeysStartingWith() should return an empty array when filtered keys do not start with a given string.
 	 */
-	public function test_should_throw_exception_when_filtered_keys_do_not_start_with_a_given_string() {
-		$message = sprintf( 'None of the searched keys start with the selected string: %s', 'taxonomy.' );
-		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( $message );
-		getAllKeysStartingWith( 'taxonomy.' );
+	public function test_should_return_empty_array_when_filtered_keys_do_not_start_with_a_given_string() {
+		$expected = [];
+		$this->assertSame( $expected, getAllKeysStartingWith( 'taxonomy.' ) );
 	}
 
 	/**
-	 * Test getAllKeysStartingWith() should throw an Exception when the store is empty.
+	 * Test getAllKeysStartingWith() should return an empty array when the store is empty.
 	 */
-	public function test_should_throw_exception_when_the_store_is_empty() {
-		Tests_GetAllKeysStartingWith::setUpBeforeClass();
-		$message = sprintf( 'None of the searched keys start with the selected string: %s', '' );
-		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( $message );
-		getAllKeysStartingWith( '' );
+	public function test_should_return_empty_array_when_the_store_is_empty() {
+		self::setUpBeforeClass();
+		$expected = [];
+		$this->assertSame( $expected, getAllKeysStartingWith( 'taxonomy.' ) );
+		$this->assertSame( $expected, getAllKeysStartingWith( '' ) );
 	}
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -69,5 +69,14 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$this->assertSame( [ 'custom_post_type.books' ], getAllKeysStartingWith( 'custom_post_type.' ) );
 	}
 
+	/**
+	 * Test getAllKeysStartingWith() should throw an Exception when filtered keys do not start with a given string.
+	 */
+	public function test_should_throw_exception_when_filtered_keys_do_not_start_with_a_given_string() {
+		$message = sprintf( 'None of the searched keys start with the selected string: %s', 'taxonomy.' );
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( $message );
+		getAllKeysStartingWith( 'taxonomy.' );
+	}
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -68,7 +68,9 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$this->assertSame( [ 'shortcode.qa' ], getAllKeysStartingWith( 'shortcode.' ) );
 		$this->assertSame( [ 'custom_post_type.books' ], getAllKeysStartingWith( 'custom_post_type.' ) );
 
-		self::setUpBeforeClass();
+		foreach ( $configs as $store_key => $config_to_store ) {
+			_the_store( $store_key, null, true );
+		}
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -28,14 +28,7 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 	 * Empty the store before starting these tests.
 	 */
 	public static function setUpBeforeClass() {
-		$store_keys = _the_store();
-		if ( empty( $store_keys ) ) {
-			return;
-		}
-
-		foreach ( array_keys( $store_keys ) as $store_key ) {
-			_the_store( $store_key, null, true );
-		}
+		self::empty_the_store();
 	}
 
 	/**
@@ -57,7 +50,7 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 			],
 			'custom_post_type.books' => [
 				'Title'  => 'The DaVinci Code',
-				'Author' => 'Dan Brown'
+				'Author' => 'Dan Brown',
 			],
 		];
 		foreach ( $configs as $store_key => $config_to_store ) {
@@ -69,9 +62,7 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$this->assertSame( [ 'custom_post_type.books' ], getAllKeysStartingWith( 'custom_post_type.' ) );
 
 		// Clean up by removing the configs (added by this test) from the store.
-		foreach ( array_keys( $configs ) as $store_key ) {
-			_the_store( $store_key, null, true );
-		}
+		self::empty_the_store( $configs );
 	}
 
 	/**
@@ -90,5 +81,37 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$this->assertSame( $expected, getAllKeysStartingWith( 'taxonomy.' ) );
 		$this->assertSame( $expected, getAllKeysStartingWith( '' ) );
 	}
-}
 
+	/**
+	 * Empty all of the configs from the store.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $configs    Optional. Array of configs stored in the store.
+	 * @param array $store_keys Optional. Array of store keys to remove from store.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	protected static function empty_the_store( $configs = [], $store_keys = [] ) {
+		// If no store keys or configs were given, grab the all configs from the store.
+		if ( empty( $store_keys ) && empty( $configs ) ) {
+			$configs = _the_store();
+			if ( empty( $configs ) ) {
+				return;
+			}
+		}
+
+		// Extract store keys from the given configs.
+		if ( empty( $store_keys ) ) {
+			$store_keys = array_keys( $configs );
+			if ( empty( $store_keys ) ) {
+				return;
+			}
+		}
+
+		foreach ( $store_keys as $store_key ) {
+			_the_store( $store_key, null, true );
+		}
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -78,5 +78,16 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$this->expectExceptionMessage( $message );
 		getAllKeysStartingWith( 'taxonomy.' );
 	}
+
+	/**
+	 * Test getAllKeysStartingWith() should throw an Exception when the store is empty.
+	 */
+	public function test_should_throw_exception_when_the_store_is_empty() {
+		Tests_GetAllKeysStartingWith::setUpBeforeClass();
+		$message = sprintf( 'None of the searched keys start with the selected string: %s', '' );
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( $message );
+		getAllKeysStartingWith( '' );
+	}
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -67,6 +67,8 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$this->assertSame( [ 'metabox.events', 'metabox.members' ], getAllKeysStartingWith( 'metabox.' ) );
 		$this->assertSame( [ 'shortcode.qa' ], getAllKeysStartingWith( 'shortcode.' ) );
 		$this->assertSame( [ 'custom_post_type.books' ], getAllKeysStartingWith( 'custom_post_type.' ) );
+
+		self::setUpBeforeClass();
 	}
 
 	/**
@@ -81,7 +83,6 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 	 * Test getAllKeysStartingWith() should return an empty array when the store is empty.
 	 */
 	public function test_should_return_empty_array_when_the_store_is_empty() {
-		self::setUpBeforeClass();
 		$expected = [];
 		$this->assertSame( $expected, getAllKeysStartingWith( 'taxonomy.' ) );
 		$this->assertSame( $expected, getAllKeysStartingWith( '' ) );

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -11,8 +11,10 @@
 
 namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
 
+use function KnowTheCode\ConfigStore\_the_store;
+use function KnowTheCode\ConfigStore\loadConfig;
 use function KnowTheCode\ConfigStore\getAllKeysStartingWith;
-use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 
 /**
  * Class Tests_GetAllKeysStartingWith
@@ -21,6 +23,51 @@ use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
  * @group   config-store
  */
 class Tests_GetAllKeysStartingWith extends Test_Case {
+
+	/**
+	 * Empty the store before starting these tests.
+	 */
+	public static function setUpBeforeClass() {
+		$store_keys = _the_store();
+		if ( empty( $store_keys ) ) {
+			return;
+		}
+
+		foreach ( array_keys( $store_keys ) as $store_key ) {
+			_the_store( $store_key, null, true );
+		}
+	}
+
+	/**
+	 * Test getAllKeysStartingWith() should filter and return all store keys that start with the given string.
+	 */
+	public function test_should_filter_and_return_all_store_keys_starting_with_given_string() {
+		$configs = [
+			'metabox.events'         => [
+				'Trinity Lutheran Church'  => 'Columbus, OH',
+				'Sanibel Episcopal Church' => 'Sanibel Island, FL',
+			],
+			'metabox.members'        => [
+				'Brandon Bird'     => 'First Trombone',
+				'Talia Marie Aull' => 'Soprano',
+			],
+			'shortcode.qa'           => [
+				'Question 1' => 'How many angels can dance on the head of a pin?',
+				'Question 2' => 'Is the moon made of green cheese?',
+			],
+			'custom_post_type.books' => [
+				'Title'  => 'The DaVinci Code',
+				'Author' => 'Dan Brown'
+			],
+		];
+		foreach ( $configs as $store_key => $config_to_store ) {
+			loadConfig( $store_key, $config_to_store );
+		}
+
+		$this->assertSame( [ 'metabox.events', 'metabox.members' ], getAllKeysStartingWith( 'metabox.' ) );
+		$this->assertSame( [ 'shortcode.qa' ], getAllKeysStartingWith( 'shortcode.' ) );
+		$this->assertSame( [ 'custom_post_type.books' ], getAllKeysStartingWith( 'custom_post_type.' ) );
+	}
 
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -68,7 +68,8 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$this->assertSame( [ 'shortcode.qa' ], getAllKeysStartingWith( 'shortcode.' ) );
 		$this->assertSame( [ 'custom_post_type.books' ], getAllKeysStartingWith( 'custom_post_type.' ) );
 
-		foreach ( $configs as $store_key => $config_to_store ) {
+		// Clean up by removing the configs (added by this test) from the store.
+		foreach ( array_keys( $configs ) as $store_key ) {
 			_the_store( $store_key, null, true );
 		}
 	}

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ *  Tests for external API function getAllKeysStartingWith()
+ *
+ * @package    spiralWebDb\centralHub\Tests\Integration\ConfigStore
+ * @since      1.3.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
+
+use function KnowTheCode\ConfigStore\getAllKeysStartingWith;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_GetAllKeysStartingWith
+ *
+ * @package spiralWebDb\centralHub\Tests\Integration\ConfigStore
+ * @group   config-store
+ */
+class Tests_GetAllKeysStartingWith extends Test_Case {
+
+}
+

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -61,19 +61,17 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
 			->times( 2 )
 			->with( 'getAllKeys', 'metabox.' )
-			->andReturnValues( [ 'events', 'members' ] );
-		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->andReturnValues( [ 'events', 'members' ] )
 			->once()
 			->with( 'getAllKeys', 'shortcode.' )
-			->andReturn( false );
-		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->andReturnValues( [] )
 			->once()
 			->with( 'getAllKeys', 'custom_post_type.' )
-			->andReturn( false );
+			->andReturnValues( [] );
+
 		$expected = [ 'events', 'members' ];
 
 		$this->assertSame( $expected, getAllKeysStartingWith( 'metabox.' ) );
 	}
-	
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -32,6 +32,41 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/api.php';
 	}
 
+	/**
+	 * Test should filter all array keys and return keys that start with substring.
+	 */
+	public function test_should_get_all_array_keys_and_filter_by_substring_that_starts_with() {
+		$config_store = [
+			'metabox.events'         => [
+				'Trinity Lutheran Church'  => 'Columbus, OH',
+				'Sanibel Episcopal Church' => 'Sanibel Island, FL',
+			],
+			'metabox.members'        => [
+				'Brandon Bird'     => 'First Trombone',
+				'Talia Marie Aull' => 'Soprano',
+			],
+			'shortcode.qa'           => [
+				'Question 1' => 'How many angels can dance on the head of a pin?',
+				'Question 2' => 'Is the moon made of green cheese?',
+			],
+			'custom_post_type.books' => [
+				'Title'  => 'The DaVinci Code',
+				'Author' => 'Dan Brown'
+			],
+		];
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
+			->once()
+			->withNoArgs()
+			->andReturn( array_keys( $config_store ) );
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->times( 4 )
+			->with( 'getAllKeys', 'metabox.' )
+			->andReturn( true );
+		$expected = [ 'events', 'members' ];
+
+		$this->assertSame( $expected, getAllKeysStartingWith( 'metabox.' ) );
+	}
+
 
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -46,19 +46,26 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 				'custom_post_type.books',
 			] );
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
-			->times( 2 )
-			->with( 'getAllKeys', 'metabox.' )
-			->andReturnValues( [ 'events', 'members' ] )
 			->once()
-			->with( 'getAllKeys', 'shortcode.' )
-			->andReturnValues( [] )
+			->with( 'metabox.events', 'metabox.' )
+			->ordered()
+			->andReturn( true )
+			->andAlsoExpectIt()
 			->once()
-			->with( 'getAllKeys', 'custom_post_type.' )
-			->andReturnValues( [] );
+			->with( 'metabox.members', 'metabox.' )
+			->ordered()
+			->andReturn( true )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'shortcode.qa', 'metabox.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'custom_post_type.books', 'metabox.' )
+			->ordered()
+			->andReturn( false );
 
-		$expected = [ 'events', 'members' ];
-
-		$this->assertSame( $expected, getAllKeysStartingWith( 'metabox.' ) );
+		$this->assertSame( [ 'metabox.events', 'metabox.members' ], getAllKeysStartingWith( 'metabox.' ) );
 	}
 }
-

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -33,9 +33,9 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 	}
 
 	/**
-	 * Test should filter all array keys and return keys that start with substring.
+	 * Test getAllKeysStartingWith() should filter and return all store keys that start with the given string.
 	 */
-	public function test_should_get_all_array_keys_and_filter_by_substring_that_starts_with() {
+	public function test_should_filter_and_return_all_store_keys_starting_with_given_string() {
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
 			->once()
 			->withNoArgs()

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -36,28 +36,15 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 	 * Test should filter all array keys and return keys that start with substring.
 	 */
 	public function test_should_get_all_array_keys_and_filter_by_substring_that_starts_with() {
-		$config_store = [
-			'metabox.events'         => [
-				'Trinity Lutheran Church'  => 'Columbus, OH',
-				'Sanibel Episcopal Church' => 'Sanibel Island, FL',
-			],
-			'metabox.members'        => [
-				'Brandon Bird'     => 'First Trombone',
-				'Talia Marie Aull' => 'Soprano',
-			],
-			'shortcode.qa'           => [
-				'Question 1' => 'How many angels can dance on the head of a pin?',
-				'Question 2' => 'Is the moon made of green cheese?',
-			],
-			'custom_post_type.books' => [
-				'Title'  => 'The DaVinci Code',
-				'Author' => 'Dan Brown'
-			],
-		];
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
 			->once()
 			->withNoArgs()
-			->andReturn( array_keys( $config_store ) );
+			->andReturn( [
+				'metabox.events',
+				'metabox.members',
+				'shortcode.qa',
+				'custom_post_type.books',
+			] );
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
 			->times( 2 )
 			->with( 'getAllKeys', 'metabox.' )

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -112,4 +112,46 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 			->andReturn( true );
 		$this->assertSame( [ 'custom_post_type.books' ], getAllKeysStartingWith( 'custom_post_type.' ) );
 	}
+
+	/**
+	 * Test getAllKeysStartingWith() should throw an Exception when filtered keys do not start with a given string.
+	 */
+	public function test_should_throw_exception_when_filtered_keys_do_not_start_with_a_given_string() {
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
+			->once()
+			->withNoArgs()
+			->andReturn( [
+				'metabox.events',
+				'metabox.members',
+				'shortcode.qa',
+				'custom_post_type.books',
+			] );
+		$message = sprintf(
+			'None of the searched keys start with the selected string: %s',
+			print_r( $starts_with, true )
+		);
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->once()
+			->with( 'metabox.events', 'taxonomy.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'metabox.members', 'taxonomy.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'shortcode.qa', 'taxonomy.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'custom_post_type.books', 'taxonomy.' )
+			->ordered()
+			->andReturn( false );
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( $message );
+		getAllKeysStartingWith( 'taxonomy.' );
+	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -13,6 +13,7 @@ namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
 
 use Brain\Monkey;
 use function KnowTheCode\ConfigStore\getAllKeysStartingWith;
+use function KnowTheCode\ConfigStore\getAllKeys;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
 /**
@@ -153,5 +154,26 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$this->expectException( \InvalidArgumentException::class );
 		$this->expectExceptionMessage( $message );
 		getAllKeysStartingWith( 'taxonomy.' );
+
+		// Empty _the_store.
+		foreach ( getAllKeys() as $store_key ) {
+			_the_store( $store_key, null, true );
+		}
+	}
+
+	/**
+	 * Test getAllKeysStartingWith() should throw an Exception when the store is empty.
+	 */
+	public function test_should_throw_exception_when_the_store_is_empty() {
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
+			->once()
+			->withNoArgs()
+			->andReturn( [] );
+		$message = sprintf( 'None of the searched keys start with the selected string: %s',
+			print_r( $starts_with, true )
+		);
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( $message );
+		getAllKeysStartingWith( '' );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -13,7 +13,6 @@ namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
 
 use Brain\Monkey;
 use function KnowTheCode\ConfigStore\getAllKeysStartingWith;
-use function KnowTheCode\ConfigStore\getAllKeys;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
 /**
@@ -115,9 +114,9 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 	}
 
 	/**
-	 * Test getAllKeysStartingWith() should throw an Exception when filtered keys do not start with a given string.
+	 * Test getAllKeysStartingWith() should return an empty array when filtered keys do not start with a given string.
 	 */
-	public function test_should_throw_exception_when_filtered_keys_do_not_start_with_a_given_string() {
+	public function test_should_return_empty_array_when_filtered_keys_do_not_start_with_a_given_string() {
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
 			->once()
 			->withNoArgs()
@@ -127,10 +126,6 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 				'shortcode.qa',
 				'custom_post_type.books',
 			] );
-		$message = sprintf(
-			'None of the searched keys start with the selected string: %s',
-			print_r( $starts_with, true )
-		);
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
 			->once()
 			->with( 'metabox.events', 'taxonomy.' )
@@ -151,29 +146,20 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 			->with( 'custom_post_type.books', 'taxonomy.' )
 			->ordered()
 			->andReturn( false );
-		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( $message );
-		getAllKeysStartingWith( 'taxonomy.' );
 
-		// Empty _the_store.
-		foreach ( getAllKeys() as $store_key ) {
-			_the_store( $store_key, null, true );
-		}
+		$this->assertSame( [], getAllKeysStartingWith( 'taxonomy.' ) );
 	}
 
 	/**
-	 * Test getAllKeysStartingWith() should throw an Exception when the store is empty.
+	 * Test getAllKeysStartingWith() should return an empty array when the store is empty.
 	 */
-	public function test_should_throw_exception_when_the_store_is_empty() {
+	public function test_should_return_empty_array_when_the_store_is_empty() {
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
-			->once()
+			->times( 2 )
 			->withNoArgs()
 			->andReturn( [] );
-		$message = sprintf( 'None of the searched keys start with the selected string: %s',
-			print_r( $starts_with, true )
-		);
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( $message );
-		getAllKeysStartingWith( '' );
+
+		$this->assertSame( [], getAllKeysStartingWith( 'taxonomy.' ) );
+		$this->assertSame( [], getAllKeysStartingWith( '' ) );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -59,14 +59,21 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 			->withNoArgs()
 			->andReturn( array_keys( $config_store ) );
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
-			->times( 4 )
+			->times( 2 )
 			->with( 'getAllKeys', 'metabox.' )
-			->andReturn( true );
+			->andReturnValues( [ 'events', 'members' ] );
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->once()
+			->with( 'getAllKeys', 'shortcode.' )
+			->andReturn( false );
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->once()
+			->with( 'getAllKeys', 'custom_post_type.' )
+			->andReturn( false );
 		$expected = [ 'events', 'members' ];
 
 		$this->assertSame( $expected, getAllKeysStartingWith( 'metabox.' ) );
 	}
-
-
+	
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -37,7 +37,7 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 	 */
 	public function test_should_filter_and_return_all_store_keys_starting_with_given_string() {
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
-			->once()
+			->times( 3 )
 			->withNoArgs()
 			->andReturn( [
 				'metabox.events',
@@ -45,6 +45,7 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 				'shortcode.qa',
 				'custom_post_type.books',
 			] );
+
 		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
 			->once()
 			->with( 'metabox.events', 'metabox.' )
@@ -65,7 +66,50 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 			->with( 'custom_post_type.books', 'metabox.' )
 			->ordered()
 			->andReturn( false );
-
 		$this->assertSame( [ 'metabox.events', 'metabox.members' ], getAllKeysStartingWith( 'metabox.' ) );
+
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->once()
+			->with( 'metabox.events', 'shortcode.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'metabox.members', 'shortcode.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'shortcode.qa', 'shortcode.' )
+			->ordered()
+			->andReturn( true )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'custom_post_type.books', 'shortcode.' )
+			->ordered()
+			->andReturn( false );
+		$this->assertSame( [ 'shortcode.qa' ], getAllKeysStartingWith( 'shortcode.' ) );
+
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->once()
+			->with( 'metabox.events', 'custom_post_type.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'metabox.members', 'custom_post_type.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'shortcode.qa', 'custom_post_type.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'custom_post_type.books', 'custom_post_type.' )
+			->ordered()
+			->andReturn( true );
+		$this->assertSame( [ 'custom_post_type.books' ], getAllKeysStartingWith( 'custom_post_type.' ) );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/config-store/getAllKeysStartingWith.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *  Tests for external API function getAllKeysStartingWith()
+ *
+ * @package    spiralWebDb\centralHub\Tests\Unit\ConfigStore
+ * @since      1.3.0
+ * @author     Robert A. Gadon
+ * @link       https://github.com/rgadon107/cornerstone
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Unit\ConfigStore;
+
+use Brain\Monkey;
+use function KnowTheCode\ConfigStore\getAllKeysStartingWith;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_GetAllKeysStartingWith
+ *
+ * @package spiralWebDb\centralHub\Tests\Unit\ConfigStore
+ * @group   config-store
+ */
+class Tests_GetAllKeysStartingWith extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/config-store/api.php';
+	}
+
+
+}
+


### PR DESCRIPTION
This PR adds tests for the config store's API function `getAllKeysStartingWith()`.  It also removes the dead code in the function.

## TODO

* [x] Add unit test for when receiving a starts with string and store has configs
* [x]  Add integration tests for same test.
* [x] Add unit test for when no store keys start with the given string
* [x] Add integration tests for same test.
* [x] Add unit test for when the store is empty.
* [x] Add integration tests for same test.