### PR TITLE
Centralized emptying the config store process for integration tests

### DIFF
--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllKeys.php
@@ -28,14 +28,7 @@ class Tests_GetAllKeys extends Test_Case {
 	 * Empty the store before starting these tests.
 	 */
 	public static function setUpBeforeClass() {
-		$configs = _the_store();
-		if ( empty( $configs ) ) {
-			return;
-		}
-
-		foreach ( array_keys( $configs ) as $store_key ) {
-			_the_store( $store_key, null, true );
-		}
+		self::empty_the_store();
 	}
 
 	/**
@@ -63,10 +56,8 @@ class Tests_GetAllKeys extends Test_Case {
 		// Get the keys and test.
 		$this->assertSame( [ 'foo', 'bar', 'baz' ], getAllKeys() );
 
-		// Remove the configurations added in this test from the store.
-		foreach ( $config_store as $store_key => $config_to_store ) {
-			_the_store( $store_key, null, true );
-		}
+		// Cleanup.
+		self::empty_the_store( $config_store );
 	}
 
 	/**
@@ -77,4 +68,3 @@ class Tests_GetAllKeys extends Test_Case {
 		$this->assertSame( $expected, getAllKeys() );
 	}
 }
-

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getAllTestsStartingWith.php
@@ -11,7 +11,6 @@
 
 namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
 
-use function KnowTheCode\ConfigStore\_the_store;
 use function KnowTheCode\ConfigStore\loadConfig;
 use function KnowTheCode\ConfigStore\getAllKeysStartingWith;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
@@ -80,38 +79,5 @@ class Tests_GetAllKeysStartingWith extends Test_Case {
 		$expected = [];
 		$this->assertSame( $expected, getAllKeysStartingWith( 'taxonomy.' ) );
 		$this->assertSame( $expected, getAllKeysStartingWith( '' ) );
-	}
-
-	/**
-	 * Empty all of the configs from the store.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $configs    Optional. Array of configs stored in the store.
-	 * @param array $store_keys Optional. Array of store keys to remove from store.
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	protected static function empty_the_store( $configs = [], $store_keys = [] ) {
-		// If no store keys or configs were given, grab the all configs from the store.
-		if ( empty( $store_keys ) && empty( $configs ) ) {
-			$configs = _the_store();
-			if ( empty( $configs ) ) {
-				return;
-			}
-		}
-
-		// Extract store keys from the given configs.
-		if ( empty( $store_keys ) ) {
-			$store_keys = array_keys( $configs );
-			if ( empty( $store_keys ) ) {
-				return;
-			}
-		}
-
-		foreach ( $store_keys as $store_key ) {
-			_the_store( $store_key, null, true );
-		}
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfig.php
@@ -40,8 +40,8 @@ class Tests_GetConfig extends Test_Case {
 		$this->assertArrayHasKey( 'foo', $actual );
 		$this->assertSame( $actual, $config );
 
-		// Clean up _the_store.
-		_the_store( __METHOD__, null, true );
+		// Clean up.
+		self::remove_from_store( __METHOD__ );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfig.php
@@ -68,4 +68,3 @@ class Tests_GetConfig extends Test_Case {
 		$this->assertSame( [], getConfig( '' ) );
 	}
 }
-

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfigParameter.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfigParameter.php
@@ -11,7 +11,6 @@
 
 namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
 
-use Brain\Monkey;
 use function KnowTheCode\ConfigStore\_the_store;
 use function KnowTheCode\ConfigStore\getConfigParameter;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfigParameter.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/getConfigParameter.php
@@ -49,7 +49,7 @@ class Tests_GetConfigParameter extends Test_Case {
 		$this->assertSame( 37, getConfigParameter( __METHOD__, 'ccc' ) );
 
 		// Clean up.
-		_the_store( __METHOD__, null, true );
+		self::remove_from_store( __METHOD__ );
 	}
 
 	/**
@@ -67,6 +67,6 @@ class Tests_GetConfigParameter extends Test_Case {
 		getConfigParameter( __METHOD__, 'key_does_not_exist' );
 
 		// Clean up.
-		_the_store( __METHOD__, null, true );
+		self::remove_from_store( __METHOD__ );
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
@@ -12,7 +12,6 @@
 namespace spiralWebDb\centralHub\Tests\Integration\ConfigStore;
 
 use function KnowTheCode\ConfigStore\loadConfig;
-use function KnowTheCode\ConfigStore\_the_store;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 
 /**
@@ -40,9 +39,8 @@ class Tests_LoadConfig extends Test_Case {
 		];
 		$this->assertTrue( loadConfig( __METHOD__, $config ) );
 
-		// Clean up _the_store.
-		_the_store( 'foo', null, true );
-		_the_store( __METHOD__, null, true );
+		// Clean up.
+		self::empty_the_store( [], [ 'foo', __METHOD__ ] );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfig.php
@@ -40,7 +40,7 @@ class Tests_LoadConfig extends Test_Case {
 		$this->assertTrue( loadConfig( __METHOD__, $config ) );
 
 		// Clean up.
-		self::empty_the_store( [], [ 'foo', __METHOD__ ] );
+		self::empty_the_store_by_keys( [ 'foo', __METHOD__ ] );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfigFromFilesystem.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/config-store/loadConfigFromFilesystem.php
@@ -16,7 +16,6 @@ use function KnowTheCode\ConfigStore\_the_store;
 use function KnowTheCode\ConfigStore\loadConfigFromFilesystem;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 
-
 /**
  * Class Tests_LoadConfigFromFilesystem
  *
@@ -42,6 +41,9 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 
 		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file, $defaults ) );
 		$this->assertEquals( $merged_config, _the_store( 'foo' ) );
+
+		// Cleanup.
+		self::remove_from_store( 'foo' );
 	}
 
 	/**
@@ -56,6 +58,9 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 
 		$this->assertSame( 'foo', loadConfigFromFilesystem( $path_to_file ) );
 		$this->assertSame( $config, _the_store( 'foo' ) );
+
+		// Cleanup.
+		self::remove_from_store( 'foo' );
 	}
 
 	/**
@@ -92,4 +97,3 @@ class Tests_LoadConfigFromFilesystem extends Test_Case {
 		loadConfigFromFilesystem( $path_to_file );
 	}
 }
-

--- a/tests/phpunit/integration/class-test-case.php
+++ b/tests/phpunit/integration/class-test-case.php
@@ -12,6 +12,7 @@
 namespace spiralWebDb\Cornerstone\Tests\Integration;
 
 use Brain\Monkey;
+use function KnowTheCode\ConfigStore\_the_store;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use spiralWebDb\Cornerstone\Tests\Test_Case_Trait;
 use WP_UnitTestCase;
@@ -48,5 +49,39 @@ abstract class Test_Case extends WP_UnitTestCase {
 	public function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();
+	}
+
+	/**
+	 * Empty all of the configs from the store.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $configs    Optional. Array of configs stored in the store.
+	 * @param array $store_keys Optional. Array of store keys to remove from store.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	protected static function empty_the_store( $configs = [], $store_keys = [] ) {
+		// If no store keys or configs were given, grab the all configs from the store.
+		if ( empty( $store_keys ) && empty( $configs ) ) {
+			$configs = _the_store();
+			if ( empty( $configs ) ) {
+				return;
+			}
+		}
+
+		// Extract store keys from the given configs.
+		if ( empty( $store_keys ) ) {
+			$store_keys = array_keys( $configs );
+			if ( empty( $store_keys ) ) {
+				return;
+			}
+		}
+
+		// Remove all configs from the store.
+		foreach ( $store_keys as $store_key ) {
+			_the_store( $store_key, null, true );
+		}
 	}
 }

--- a/tests/phpunit/integration/class-test-case.php
+++ b/tests/phpunit/integration/class-test-case.php
@@ -56,30 +56,34 @@ abstract class Test_Case extends WP_UnitTestCase {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array $configs    Optional. Array of configs stored in the store.
-	 * @param array $store_keys Optional. Array of store keys to remove from store.
+	 * @param array $configs Optional. Array of configs stored in the store.
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	protected static function empty_the_store( $configs = [], $store_keys = [] ) {
+	protected static function empty_the_store( $configs = [] ) {
 		// If no store keys or configs were given, grab the all configs from the store.
-		if ( empty( $store_keys ) && empty( $configs ) ) {
+		if ( empty( $configs ) ) {
 			$configs = _the_store();
 			if ( empty( $configs ) ) {
 				return;
 			}
 		}
 
-		// Extract store keys from the given configs.
-		if ( empty( $store_keys ) ) {
-			$store_keys = array_keys( $configs );
-			if ( empty( $store_keys ) ) {
-				return;
-			}
-		}
+		self::empty_the_store_by_keys( array_keys( $configs ) );
+	}
 
-		// Remove all configs from the store.
+	/**
+	 * Empty all of the configs from the store for the given keys.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $store_keys Array of store keys to remove from store.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	protected static function empty_the_store_by_keys( $store_keys ) {
 		foreach ( $store_keys as $store_key ) {
 			self::remove_from_store( $store_key );
 		}

--- a/tests/phpunit/integration/class-test-case.php
+++ b/tests/phpunit/integration/class-test-case.php
@@ -81,7 +81,21 @@ abstract class Test_Case extends WP_UnitTestCase {
 
 		// Remove all configs from the store.
 		foreach ( $store_keys as $store_key ) {
-			_the_store( $store_key, null, true );
+			self::remove_from_store( $store_key );
 		}
+	}
+
+	/**
+	 * Remove the config from the store by the given store key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $store_key Key for the config to remove from store.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	protected static function remove_from_store( $store_key ) {
+		_the_store( $store_key, null, true );
 	}
 }


### PR DESCRIPTION
The process of emptying the config store or removing a specific config is distributed throughout the integration tests.  That's problematic as if the mechanism to "remove" changes, we'd have to change it in multiple places in the test suite.  That's the wrong approach.

This PR centralizes the process by moving it into the Test Case of the integration suite.  The advantages are:

1. Tests no longer need to know anything about "how to empty the store."  That knowledge is located in one spot.
2. Keeps the code DRY.
3. Reduces the amount of code in tests.
4. Makes it easier to set up a test that relies on the config store.