### PR TITLE
PR #29 (add/registerMetaBoxes)

### DIFF
--- a/mu-plugins/central-hub/src/meta-data/meta-box.php
+++ b/mu-plugins/central-hub/src/meta-data/meta-box.php
@@ -39,6 +39,8 @@ function register_meta_boxes() {
 			$config['priority'],
 			$config['callback_args']
 		);
+
+		return true;
 	}
 }
 

--- a/mu-plugins/central-hub/src/meta-data/meta-box.php
+++ b/mu-plugins/central-hub/src/meta-data/meta-box.php
@@ -25,7 +25,6 @@ add_action( 'admin_menu', __NAMESPACE__ . '\register_meta_boxes' );
  */
 function register_meta_boxes() {
 	foreach ( get_meta_box_keys() as $store_key ) {
-
 		$config = configStore\getConfigParameter(
 			$store_key,
 			'add_meta_box'
@@ -40,8 +39,6 @@ function register_meta_boxes() {
 			$config['priority'],
 			$config['callback_args']
 		);
-
-		return true;
 	}
 }
 

--- a/mu-plugins/central-hub/src/meta-data/meta-box.php
+++ b/mu-plugins/central-hub/src/meta-data/meta-box.php
@@ -18,9 +18,9 @@ add_action( 'admin_menu', __NAMESPACE__ . '\register_meta_boxes' );
 /**
  * Register the meta boxes.
  *
- * @since 1.0.0
+ * @since 1.1.0
  *
- * @return void
+ * @return true|null  boolean  True if $store_key starts with 'metabox.'.
  */
 function register_meta_boxes() {
 	foreach ( get_meta_box_keys() as $store_key ) {

--- a/mu-plugins/central-hub/src/meta-data/meta-box.php
+++ b/mu-plugins/central-hub/src/meta-data/meta-box.php
@@ -20,7 +20,8 @@ add_action( 'admin_menu', __NAMESPACE__ . '\register_meta_boxes' );
  *
  * @since 1.1.0
  *
- * @return true|null  boolean  True if $store_key starts with 'metabox.'.
+ * @return true|void Returns true if $store_key starts with 'metabox.'; else returns void
+ * @throws \Exception
  */
 function register_meta_boxes() {
 	foreach ( get_meta_box_keys() as $store_key ) {

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -31,6 +31,9 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 		self::empty_the_store();
 	}
 
+	/**
+	 * Set up each test.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -40,9 +43,9 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 		}
 	}
 
-	/*
-    * Test register_meta_boxes() should register the configured meta box with WordPress.
-    */
+	/**
+	 * Test register_meta_boxes() should register the configured meta box with WordPress.
+	 */
 	function test_should_register_configured_meta_box_with_wordpress() {
 		$configs = [
 			'meta_box.events' => [
@@ -78,9 +81,9 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 		self::remove_from_store( 'meta_box.events' );
 	}
 
-	/*
-    * Test register_meta_boxes() returns null when no store key starts with 'metabox.'.
-    */
+	/**
+	 * Test register_meta_boxes() returns null when no store key starts with 'metabox.'.
+	 */
 	public function test_function_should_return_null_when_no_store_key_starts_with_metabox() {
 		$configs = [
 			'taxonomy.roles'         => [

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -38,6 +38,7 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 		$configs = [
 			'metabox.events' => [
 				'add_meta_box' => [
+					'id'            => 'events',
 					'title'         => 'Event Info',
 					'screen'        => 'events',
 					'context'       => 'advanced',
@@ -54,6 +55,8 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 			->once()
 			->with( 'metabox.events' )
 			->andReturn( 'events' );
+		Monkey\Functions\expect( 'spiralWebDB\Metadata\render_meta_box' )
+			->never();
 
 		$this->assertTrue( register_meta_boxes() );
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for the function register_meta_boxes().
+ *
+ * @package     spiralWebDb\centralHub\Tests\Unit\Metadata
+ * @since       1.3.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Integration\Metadata;
+
+use Brain\Monkey;
+use function spiralWebDB\Metadata\register_meta_boxes;
+use function KnowTheCode\ConfigStore\loadConfig;
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+
+/**
+ * Class Tests_RegisterMetaBoxes
+ *
+ * @package spiralWebDb\centralHub\Tests\Integration\Metadata
+ * @group   meta-data
+ */
+class Tests_RegisterMetaBoxes extends Test_Case {
+
+	/**
+	 * Empty the store before starting these tests.
+	 */
+	public static function setUpBeforeClass() {
+		self::empty_the_store();
+	}
+
+	/*
+    * Test register_meta_boxes() will add a meta box for each store key that starts with 'metabox.'.
+    */
+	function test_function_will_add_a_meta_box_for_each_store_key_that_starts_with_metabox() {
+		$configs = [
+			'metabox.events' => [
+				'add_meta_box' => [
+					'title'         => 'Event Info',
+					'screen'        => 'events',
+					'context'       => 'advanced',
+					'priority'      => 'default',
+					'callback_args' => null
+				]
+			]
+		];
+		foreach ( $configs as $store_key => $config_to_store ) {
+			loadConfig( $store_key, $config_to_store );
+		}
+
+		$this->assertTrue( register_meta_boxes() );
+
+		self::empty_the_store_by_keys( [ 'metabox.events' ] );
+	}
+
+	/*
+    * Test register_meta_boxes() returns null when no store key starts with 'metabox.'.
+    */
+	public function test_function_should_return_null_when_no_store_key_starts_with_metabox() {
+		$configs = [
+			'taxonomy.roles'         => [
+				'Soprano' => 'Soprano (vocalist)'
+			],
+			'shortcode.qa'           => [
+				'Question 1' => 'How many angels can dance on the head of a pin?'
+			],
+			'custom_post_type.books' => [
+				'Title' => 'To Kill a Mockingbird',
+			]
+		];
+		foreach ( $configs as $store_key => $config_to_store ) {
+			loadConfig( $store_key, $config_to_store );
+		}
+
+		$this->assertNull( register_meta_boxes() );
+
+		self::empty_the_store_by_keys(
+			[ 'taxonomy.roles', 'shortcode.qa', 'custom_post_type.books' ]
+		);
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -50,6 +50,11 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 			loadConfig( $store_key, $config_to_store );
 		}
 
+		Monkey\Functions\expect( 'spiralWebDB\Metadata\get_meta_box_id' )
+			->once()
+			->with( 'metabox.events' )
+			->andReturn( 'events' );
+
 		$this->assertTrue( register_meta_boxes() );
 
 		self::empty_the_store_by_keys( [ 'metabox.events' ] );

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -82,9 +82,10 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 	}
 
 	/**
-	 * Test register_meta_boxes() should return null when no store key starts with 'meta_box.'.
+	 * Test register_meta_boxes() should not register meta boxes when there are no store keys that start with
+	 * 'meta_box.'.
 	 */
-	public function test_should_return_null_when_no_store_key_starts_with_meta_box() {
+	public function test_should_not_register_meta_boxes_when_no_store_keys_start_with_meta_box() {
 		$configs = [
 			'taxonomy.roles'         => [
 				'Soprano' => 'Soprano (vocalist)',
@@ -100,7 +101,13 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 			loadConfig( $store_key, $config_to_store );
 		}
 
-		$this->assertNull( register_meta_boxes() );
+		global $wp_meta_boxes;
+		$pre = $wp_meta_boxes;
+
+		register_meta_boxes();
+
+		// Test that no additional meta boxes were registered.
+		$this->assertSame( $pre, $wp_meta_boxes );
 
 		self::empty_the_store_by_keys(
 			[ 'taxonomy.roles', 'shortcode.qa', 'custom_post_type.books' ]

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -67,8 +67,9 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 		// Test state prior to registering the meta box.
 		$this->assertArrayNotHasKey( 'events', $wp_meta_boxes );
 
+		register_meta_boxes();
+
 		// Test the meta box is registered.
-		$this->assertTrue( register_meta_boxes() );
 		$this->assertArrayHasKey( 'events', $wp_meta_boxes['events']['advanced']['default'] );
 		$meta_box = $wp_meta_boxes['events']['advanced']['default']['events'];
 		$this->assertSame( $configs['meta_box.events']['add_meta_box']['id'], $meta_box['id'] );

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -82,9 +82,9 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 	}
 
 	/**
-	 * Test register_meta_boxes() returns null when no store key starts with 'metabox.'.
+	 * Test register_meta_boxes() should return null when no store key starts with 'meta_box.'.
 	 */
-	public function test_function_should_return_null_when_no_store_key_starts_with_metabox() {
+	public function test_should_return_null_when_no_store_key_starts_with_meta_box() {
 		$configs = [
 			'taxonomy.roles'         => [
 				'Soprano' => 'Soprano (vocalist)',

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -11,7 +11,6 @@
 
 namespace spiralWebDb\centralHub\Tests\Integration\Metadata;
 
-use Brain\Monkey;
 use function spiralWebDB\Metadata\register_meta_boxes;
 use function KnowTheCode\ConfigStore\loadConfig;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
@@ -34,9 +34,9 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 	}
 
 	/*
-	 * Test that register_meta_boxes() should register to admin_menu hook when event fires.
+	 * Test register_meta_boxes() should register to add_action( 'admin_menu' ) when event fires.
 	 */
-	public function test_that_function_registers_when_admin_menu_event_fires() {
+	public function test_function_should_register_to_action_hook_when_event_fires() {
 		$this->assertTrue( has_action( 'admin_menu', 'spiralWebDB\Metadata\register_meta_boxes' ) );
 	}
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
@@ -15,7 +15,6 @@ use Brain\Monkey;
 use function spiralWebDB\Metadata\register_meta_boxes;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
-
 /**
  * Class Tests_RegisterMetaBoxes
  *
@@ -73,4 +72,3 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 		$this->assertNull( register_meta_boxes() );
 	}
 }
-

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
@@ -31,16 +31,34 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 		parent::setUp();
 
 		require_once CENTRAL_HUB_ROOT_DIR . '/src/meta-data/meta-box.php';
-
 	}
 
 	/*
-	 * Test that the 'admin_menu' add_action() event actually fires.
+	 * Test that register_meta_boxes() should register to admin_menu hook when event fires.
 	 */
-	public function test_that_admin_menu_add_action_event_fires() {
-
-		register_meta_boxes();
-
+	public function test_that_function_registers_when_admin_menu_event_fires() {
 		$this->assertTrue( has_action( 'admin_menu', 'spiralWebDB\Metadata\register_meta_boxes' ) );
 	}
+
+	/*
+	 * Test register_meta_boxes() will add a meta box for each store key that starts with 'metabox.'.
+	 */
+	function test_function_will_add_a_meta_box_for_each_store_key_that_starts_with_metabox() {
+		Monkey\Functions\expect( 'spiralWebDB\Metadata\get_meta_box_keys' )
+			->once()
+			->withNoArgs()
+			->andReturn( [ 'meta_box.events' ] );
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getConfigParameter' )
+			->once()
+			->with( 'meta_box.events', 'add_meta_box' );
+		Monkey\Functions\when( 'spiralWebDB\Metadata\add_meta_box' )
+			->justReturn( 'events' );
+		Monkey\Functions\expect( 'spiralWebDB\Metadata\get_meta_box_id' )
+			->once()
+			->with( 'meta_box.events' )
+			->andReturn( 'events' );
+
+		$this->assertTrue( register_meta_boxes() );
+	}
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
@@ -57,7 +57,7 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 			->with( 'meta_box.events' )
 			->andReturn( 'events' );
 
-		$this->assertTrue( register_meta_boxes() );
+		$this->assertNull( register_meta_boxes() );
 	}
 
 	/*

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for the function register_meta_boxes().
+ *
+ * @package     spiralWebDb\centralHub\Tests\Unit\Metadata
+ * @since       1.3.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Unit\Metadata;
+
+use Brain\Monkey;
+use function spiralWebDB\Metadata\register_meta_boxes;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+
+
+/**
+ * Class Tests_RegisterMetaBoxes
+ *
+ * @package spiralWebDb\centralHub\Tests\Unit\Metadata
+ * @group   meta-data
+ */
+class Tests_RegisterMetaBoxes extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/meta-data/meta-box.php';
+
+	}
+
+	/*
+	 * Test that the 'admin_menu' add_action() event actually fires.
+	 */
+	public function test_that_admin_menu_add_action_event_fires() {
+
+		register_meta_boxes();
+
+		$this->assertTrue( has_action( 'admin_menu', 'spiralWebDB\Metadata\register_meta_boxes' ) );
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
@@ -60,5 +60,17 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 
 		$this->assertTrue( register_meta_boxes() );
 	}
+
+	/*
+	 * Test register_meta_boxes() returns null when no store key starts with 'metabox.'.
+	 */
+	public function test_function_should_return_null_when_no_store_key_starts_with_metabox() {
+		Monkey\Functions\expect( 'spiralWebDB\Metadata\get_meta_box_keys' )
+			->once()
+			->withNoArgs()
+			->andReturn( [] );
+
+		$this->assertNull( register_meta_boxes() );
+	}
 }
 


### PR DESCRIPTION
Adds a test suite for the `register_meta_boxes()` function in the Metadata API.