### PR TITLE
PR #37 (add/getMetaBoxKeys)

### DIFF
--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
@@ -41,9 +41,6 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 	 * Test get_meta_box_keys() returns empty array when store key is empty.
 	 */
 	public function test_returns_empty_array_when_store_key_is_empty() {
-		loadConfig( '', [] );
-		get_meta_box_keys();
-
 		$this->assertArrayNotHasKey( 'meta_box.', get_meta_box_keys() );
 		$this->assertSame( [], get_meta_box_keys() );
 	}

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
@@ -72,3 +72,4 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 		self::empty_the_store( $configs );
 	}
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Tests for the function get_meta_box_keys().
+ *
+ * @package     spiralWebDb\centralHub\Tests\Integration\Metadata
+ * @since       1.3.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Integration\Metadata;
+
+use function KnowTheCode\ConfigStore\loadConfig;
+use function spiralWebDB\Metadata\get_meta_box_keys;
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+
+/**
+ * Class Tests_GetMetaBoxKeys
+ *
+ * @package spiralWebDb\centralHub\Tests\Integration\Metadata
+ * @group   meta-data
+ */
+class Tests_GetMetaBoxKeys extends Test_Case {
+
+	/**
+	 * Empty the store before starting these tests.
+	 */
+	public static function setUpBeforeClass() {
+		self::empty_the_store();
+	}
+
+	/**
+	 * Test get_meta_box_keys() returns empty array when store key is empty or does not start with 'meta_box.'
+	 */
+	public function test_returns_empty_array_when_store_key_is_empty_or_does_not_begin_with_meta_box() {
+		loadConfig( '', [] );
+		get_meta_box_keys();
+
+		$this->assertSame( [], get_meta_box_keys() );
+	}
+
+	/**
+	 * Test get_meta_box_keys() returns all array keys that start with `meta_box.`
+	 */
+	public function test_returns_all_array_keys_that_start_with_meta_box() {
+		$configs = [
+			'meta_box.events'        => [
+				'Trinity Lutheran Church'  => 'Columbus, OH',
+				'Sanibel Episcopal Church' => 'Sanibel Island, FL',
+			],
+			'meta_box.members'       => [
+				'Brandon Bird'     => 'First Trombone',
+				'Talia Marie Aull' => 'Soprano',
+			],
+			'shortcode.qa'           => [
+				'Question 1' => 'How many angels can dance on the head of a pin?',
+				'Question 2' => 'Is the moon made of green cheese?',
+			],
+			'custom_post_type.books' => [
+				'Title'  => 'The DaVinci Code',
+				'Author' => 'Dan Brown',
+			],
+		];
+		foreach ( $configs as $store_key => $config_to_store ) {
+			loadConfig( $store_key, $config_to_store );
+		}
+
+		$this->assertSame( [ 'meta_box.events', 'meta_box.members' ], get_meta_box_keys() );
+
+		// Clean up.
+		self::empty_the_store( $configs );
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
@@ -59,7 +59,6 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 			],
 		];
 		loadConfig( 'notametabox.members', $configs['notametabox.members'] );
-		get_meta_box_keys();
 
 		$this->assertArrayNotHasKey( 'meta_box.', get_meta_box_keys() );
 		$this->assertSame( [], get_meta_box_keys() );

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
@@ -31,10 +31,36 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 	}
 
 	/**
-	 * Test get_meta_box_keys() returns empty array when store key is empty or does not start with 'meta_box.'
+	 * Clean up the test environment after each test.
 	 */
-	public function test_returns_empty_array_when_store_key_is_empty_or_does_not_begin_with_meta_box() {
+	public function tearDown() {
+		self::empty_the_store();
+	}
+
+	/**
+	 * Test get_meta_box_keys() returns empty array when store key is empty.
+	 */
+	public function test_returns_empty_array_when_store_key_is_empty() {
 		loadConfig( '', [] );
+		get_meta_box_keys();
+
+		$this->assertSame( [], get_meta_box_keys() );
+	}
+
+	/**
+	 * Test get_meta_box_keys() returns empty array when store key does not start with `meta_box`.
+	 */
+	public function test_returns_empty_array_when_store_key_does_not_start_with_meta_box() {
+		$configs = [
+			'notametabox.members' => [
+				'add_meta_box' => [
+					'id'      => 'members',
+					'screen'  => 'members',
+					'context' => 'normal',
+				],
+			],
+		];
+		loadConfig( 'notametabox.members', $configs['notametabox.members'] );
 		get_meta_box_keys();
 
 		$this->assertSame( [], get_meta_box_keys() );
@@ -67,9 +93,5 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 		}
 
 		$this->assertSame( [ 'meta_box.events', 'meta_box.members' ], get_meta_box_keys() );
-
-		// Clean up.
-		self::empty_the_store( $configs );
 	}
 }
-

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getMetaBoxKeys.php
@@ -44,6 +44,7 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 		loadConfig( '', [] );
 		get_meta_box_keys();
 
+		$this->assertArrayNotHasKey( 'meta_box.', get_meta_box_keys() );
 		$this->assertSame( [], get_meta_box_keys() );
 	}
 
@@ -63,6 +64,7 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 		loadConfig( 'notametabox.members', $configs['notametabox.members'] );
 		get_meta_box_keys();
 
+		$this->assertArrayNotHasKey( 'meta_box.', get_meta_box_keys() );
 		$this->assertSame( [], get_meta_box_keys() );
 	}
 

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
@@ -80,3 +80,4 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 		$this->assertSame( [ 'meta_box.events', 'meta_box.members' ], get_meta_box_keys() );
 	}
 }
+

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
@@ -47,36 +47,10 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 	 * Test get_meta_box_keys() returns all array keys that start with `meta_box.`
 	 */
 	public function test_returns_all_array_keys_that_start_with_meta_box() {
-		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeysStartingWith' )
 			->once()
-			->withNoArgs()
-			->andReturn( [
-				'meta_box.events',
-				'meta_box.members',
-				'shortcode.qa',
-				'custom_post_type.books',
-			] );
-
-		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
-			->once()
-			->with( 'meta_box.events', 'meta_box.' )
-			->ordered()
-			->andReturn( true )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'meta_box.members', 'meta_box.' )
-			->ordered()
-			->andReturn( true )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'shortcode.qa', 'meta_box.' )
-			->ordered()
-			->andReturn( false )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'custom_post_type.books', 'meta_box.' )
-			->ordered()
-			->andReturn( false );
+			->with( 'meta_box.' )
+			->andReturn( [ 'meta_box.events', 'meta_box.members' ] );
 
 		$this->assertSame( [ 'meta_box.events', 'meta_box.members' ], get_meta_box_keys() );
 	}

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Tests for the function get_meta_box_keys().
+ *
+ * @package     spiralWebDb\centralHub\Tests\Unit\Metadata
+ * @since       1.3.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Unit\Metadata;
+
+use Brain\Monkey;
+use function spiralWebDB\Metadata\get_meta_box_keys;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_GetMetaBoxKeys
+ *
+ * @package spiralWebDb\centralHub\Tests\Unit\Metadata
+ * @group   meta-data
+ */
+class Tests_GetMetaBoxKeys extends Test_Case {
+
+	/**
+	 * Prepare the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/meta-data/helpers.php';
+	}
+
+	/**
+	 * Test get_meta_box_keys() returns empty array when store key is empty or does not start with 'meta_box.'
+	 */
+	public function test_returns_empty_array_when_store_key_is_empty_or_does_not_begin_with_meta_box() {
+		$expected = [];
+		get_meta_box_keys();
+
+		$this->assertSame( $expected, get_meta_box_keys() );
+	}
+
+	/**
+	 * Test get_meta_box_keys() returns all array keys that start with `meta_box.`
+	 */
+	public function test_returns_all_array_keys_that_start_with_meta_box() {
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getAllKeys' )
+			->once()
+			->withNoArgs()
+			->andReturn( [
+				'meta_box.events',
+				'meta_box.members',
+				'shortcode.qa',
+				'custom_post_type.books',
+			] );
+
+		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\str_starts_with' )
+			->once()
+			->with( 'meta_box.events', 'meta_box.' )
+			->ordered()
+			->andReturn( true )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'meta_box.members', 'meta_box.' )
+			->ordered()
+			->andReturn( true )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'shortcode.qa', 'meta_box.' )
+			->ordered()
+			->andReturn( false )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'custom_post_type.books', 'meta_box.' )
+			->ordered()
+			->andReturn( false );
+
+		$this->assertSame( [ 'meta_box.events', 'meta_box.members' ], get_meta_box_keys() );
+	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
@@ -36,11 +36,8 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 	 * Test get_meta_box_keys() returns empty array when store key is empty or does not start with 'meta_box.'
 	 */
 	public function test_returns_empty_array_when_store_key_is_empty_or_does_not_begin_with_meta_box() {
-		$expected = [];
-		get_meta_box_keys();
-
 		$this->assertArrayNotHasKey( 'meta_box.', get_meta_box_keys() );
-		$this->assertSame( $expected, get_meta_box_keys() );
+		$this->assertSame( [], get_meta_box_keys() );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getMetaBoxKeys.php
@@ -39,6 +39,7 @@ class Tests_GetMetaBoxKeys extends Test_Case {
 		$expected = [];
 		get_meta_box_keys();
 
+		$this->assertArrayNotHasKey( 'meta_box.', get_meta_box_keys() );
 		$this->assertSame( $expected, get_meta_box_keys() );
 	}
 


### PR DESCRIPTION
`get_meta_box_keys()` is a helper function for the meta box generator within the Central Hub plugin . The file path (relative to the Git repo) is: 

>`/wp-content/mu-plugins/central-hub/src/meta-data/helpers.php` . 

The function filters all meta box configurations by the store key starting with the string `'meta_box.'`.  It is a wrapper function for `getAllKeysStartingWith()` located in the `config-store` module of Central Hub.  `get_meta_box_keys()` is a dependent function used within  `register_meta_box()` and  `save_meta_boxes()`. 

This PR contains the unit and integration tests for `get_meta_box_keys()`. 