### PR TITLE
PR #43 (add/getCustomFieldsValues) | integration tests only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /plugins/members-role-hierarchy
 /plugins/ninja-forms
 /plugins/query-monitor
+/plugins/Sandbox-Workspace
 /plugins/sg-cachepress
 /plugins/simple-page-ordering
 /plugins/update-control

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -149,7 +149,9 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	 */
 	public function test_filter_registers_callback_and_returns_true_with_cb_priority_level() {
 		// Register anonymous callback to filter $tag with priority of 20 and 3 arguments.
-		add_filter( 'filter_meta_box_custom_fields', function ( $custom_fields ) {
+		add_filter( 'filter_meta_box_custom_fields', __NAMESPACE__ . '\custom_callback', 20, 3 );
+
+		function custom_callback() {
 			$expected_callback_args = [
 				0 => [
 					'event-date' => '',

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -48,14 +48,7 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 		// Create and get the post_id via the factory method.
 		$this->post = self::factory()->post->create();
 	}
-
-	/**
-	 * Clean up the test environment after each test.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-	}
-
+	
 	/**
 	 * Test get_custom_fields_values() should return an empty array when custom fields config is empty.
 	 */

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -106,7 +106,46 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 		];
 
 		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
+
+		// Clean up database.
+		delete_post_meta( $this->post, 'event-date', '10-04-2019' );
+		delete_post_meta( $this->post, 'event-time', '19:30:00' );
+		delete_post_meta( $this->post, 'venue-name', 'Carnegie Hall' );
 	}
 
-		// Test get_custom_fields_values() should return default value from meta box config when post meta key does not exist.
+	/**
+	 * Test get_custom_fields_values() should return custom fields default values when post meta is not in database.
+	 */
+	public function test_should_return_custom_fields_default_values_when_post_meta_is_not_in_database() {
+		$config = [
+			'custom_fields' => [
+				'event-date' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'event-time' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'venue-name' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+			],
+		];
+
+		// Check that database does not contain post meta.
+		$this->assertSame( '', get_post_meta( $this->post, 'event-date', true ) );
+		$this->assertSame( '', get_post_meta( $this->post, 'event-time', true ) );
+		$this->assertSame( '', get_post_meta( $this->post, 'venue-name', true ) );
+
+		$expected_custom_fields = [
+			'event-date' => '',
+			'event-time' => '',
+			'venue-name' => '',
+		];
+
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
 	}
+}
+

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -48,7 +48,7 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 		// Create and get the post_id via the factory method.
 		$this->post = self::factory()->post->create();
 	}
-	
+
 	/**
 	 * Test get_custom_fields_values() should return an empty array when custom fields config is empty.
 	 */
@@ -101,9 +101,9 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
 
 		// Clean up database.
-		delete_post_meta( $this->post, 'event-date', '10-04-2019' );
-		delete_post_meta( $this->post, 'event-time', '19:30:00' );
-		delete_post_meta( $this->post, 'venue-name', 'Carnegie Hall' );
+		delete_post_meta( $this->post, 'event-date' );
+		delete_post_meta( $this->post, 'event-time' );
+		delete_post_meta( $this->post, 'venue-name' );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -50,9 +50,9 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	}
 
 	/**
-	 * Test get_custom_fields_values() should return an empty array when config store is empty.
+	 * Test get_custom_fields_values() should return an empty array when custom fields config is empty.
 	 */
-	public function test_should_return_empty_array_when_config_store_is_empty() {
+	public function test_should_return_empty_array_when_custom_fields_config_is_empty() {
 		$config = [
 			'custom_fields' => [],
 		];

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -11,9 +11,9 @@
 
 namespace spiralWebDb\centralHub\Tests\Integration\Metadata;
 
-use function KnowTheCode\ConfigStore\loadConfig;
 use function get_post_meta;
 use function add_post_meta;
+use function delete_post_meta;
 use function spiralWebDB\Metadata\get_custom_fields_values;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -11,12 +11,6 @@
 
 namespace spiralWebDb\centralHub\Tests\Integration\Metadata;
 
-use function get_post_meta;
-use function add_post_meta;
-use function delete_post_meta;
-use function add_filter;
-use function has_filter;
-use function remove_all_filters;
 use function spiralWebDB\Metadata\get_custom_fields_values;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -91,18 +91,14 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 		$this->assertSame( '19:30:00', get_post_meta( $this->post, 'event-time', true ) );
 		$this->assertSame( 'Carnegie Hall', get_post_meta( $this->post, 'venue-name', true ) );
 
-		$expected = [
-			'meta_box.events' => [
-				'custom_fields' => [
-					'event-date' => '10-04-2019',
-					'event-time' => '19:30:00',
-					'venue-name' => 'Carnegie Hall',
-				]
-			],
+		$expected_custom_fields = [
+			'event-date' => '10-04-2019',
+			'event-time' => '19:30:00',
+			'venue-name' => 'Carnegie Hall',
 		];
 
-		$this->assertSame( $expected['meta_box.events'], get_custom_fields_values( $this->post, 'events', $config ) );
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
 	}
 
-	// Test get_custom_fields_values() should return default value from meta box config when post meta key does not exist.
-}
+		// Test get_custom_fields_values() should return default value from meta box config when post meta key does not exist.
+	}

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -36,6 +36,13 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	protected $post;
 
 	/**
+	 * Array of configuration parameters.
+	 *
+	 * @var array
+	 */
+	protected $config = [];
+
+	/**
 	 * Empty the store before starting these tests.
 	 */
 	public static function setUpBeforeClass() {
@@ -49,7 +56,23 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 		parent::setUp();
 
 		// Create and get the post_id via the factory method.
-		$this->post = self::factory()->post->create();
+		$this->post   = self::factory()->post->create();
+		$this->config = $config = [
+			'custom_fields' => [
+				'event-date' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'event-time' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'venue-name' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+			],
+		];
 	}
 
 	/**
@@ -68,23 +91,6 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	 * config.
 	 */
 	public function test_should_return_post_meta_from_database_when_meta_key_exists_in_custom_fields_config() {
-		$config = [
-			'custom_fields' => [
-				'event-date' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'event-time' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'venue-name' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-			],
-		];
-
 		// Add post meta to the database so we have something to call.
 		add_post_meta( $this->post, 'event-date', '10-04-2019' );
 		add_post_meta( $this->post, 'event-time', '19:30:00' );
@@ -101,7 +107,7 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			'venue-name' => 'Carnegie Hall',
 		];
 
-		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $this->config ) );
 
 		// Clean up database.
 		delete_post_meta( $this->post, 'event-date' );
@@ -113,23 +119,6 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	 * Test get_custom_fields_values() should return custom fields default values when post meta is not in database.
 	 */
 	public function test_should_return_custom_fields_default_values_when_post_meta_is_not_in_database() {
-		$config = [
-			'custom_fields' => [
-				'event-date' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'event-time' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'venue-name' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-			],
-		];
-
 		// Check that database does not contain post meta.
 		$this->assertSame( '', get_post_meta( $this->post, 'event-date', true ) );
 		$this->assertSame( '', get_post_meta( $this->post, 'event-time', true ) );
@@ -141,30 +130,13 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			'venue-name' => '',
 		];
 
-		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $this->config ) );
 	}
 
 	/**
 	 * Test get_custom_fields_values() should return filtered custom field values.
 	 */
 	public function test_should_return_filtered_custom_field_values() {
-		$config = [
-			'custom_fields' => [
-				'event-date' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'event-time' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'venue-name' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-			],
-		];
-
 		// Add post meta to the database so we have something to call.
 		add_post_meta( $this->post, 'event-date', '10-12-2019' );
 		add_post_meta( $this->post, 'event-time', '19:30:00' );
@@ -185,7 +157,7 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			'event-time' => '15:00:00',
 			'venue-name' => 'The Fabulous Fox Theater',
 		];
-		$this->assertSame( $updated_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
+		$this->assertSame( $updated_custom_fields, get_custom_fields_values( $this->post, 'events', $this->config ) );
 
 		// Clean up.
 		remove_all_filters( 'filter_meta_box_custom_fields', 20 );

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -50,6 +50,13 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	}
 
 	/**
+	 * Clean up the test environment after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	/**
 	 * Test get_custom_fields_values() should return an empty array when custom fields config is empty.
 	 */
 	public function test_should_return_empty_array_when_custom_fields_config_is_empty() {

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -145,9 +145,9 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	}
 
 	/**
-	 * Test get_custom_fields_values() should register a custom callback and return true with callback priority level.
+	 * Test get_custom_fields_values() should return filtered custom field values.
 	 */
-	public function test_filter_registers_custom_callback_and_returns_true_with_cb_priority_level() {
+	public function test_should_return_filtered_custom_field_values() {
 		$config = [
 			'custom_fields' => [
 				'event-date' => [

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -61,22 +61,26 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	}
 
 	/**
-	 * Test get_custom_fields_values() should return post meta from the database when post meta key exists.
+	 * Test get_custom_fields_values() should return post meta from database when meta key exists in custom fields config.
 	 */
-	public function test_should_return_post_meta_from_database_when_post_meta_key_exists() {
+	public function test_should_return_post_meta_from_database_when_meta_key_exists_in_custom_fields_config() {
 		$config = [
-			'meta_box.events' => [
-				'custom_fields' => [
-					'event-date' => '',
-					'event-time' => '',
-					'venue-name' => '',
-				]
+			'custom_fields' => [
+				'event-date' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'event-time' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'venue-name' => [
+					'is_single' => true,
+					'default'   => '',
+				],
 			],
 		];
-		foreach ( $config as $store_key => $config_to_store ) {
-			loadConfig( 'meta_box.events', $config['meta_box.events'] );
-		}
-//		var_dump( getConfig( 'meta_box.events' ) );
+
 		// Add post meta to the database so we have something to call.
 		add_post_meta( $this->post, 'event-date', '10-04-2019' );
 		add_post_meta( $this->post, 'event-time', '19:30:00' );

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -140,5 +140,16 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 
 		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
 	}
+
+	/**
+	 * Test get_custom_fields_values() should return true when filter tag has registered callback.
+	 */
+	public function test_should_return_true_when_filter_tag_has_registered_callback() {
+		// Register anonymous callback to filter $tag with priority of 20.
+		add_filter( 'filter_meta_box_custom_fields', __FUNCTION__, 20 );
+
+		$this->assertTrue( has_filter( 'filter_meta_box_custom_fields' ) );
+		$this->assertEquals( 20, has_filter( 'filter_meta_box_custom_fields', __FUNCTION__ ) );
+	}
 }
 

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -173,10 +173,11 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			];
 
 			$this->assertSame( $update_custom_fields, func_get_args() );
-		}, 20, 3 );
+		}
 
 		// Check if any callback has been registered to the filter hook
 		$this->assertTrue( has_filter( 'filter_meta_box_custom_fields' ) );
+		$this->assertEquals( 20, has_filter( 'filter_meta_box_custom_fields', __NAMESPACE__ . '\custom_callback' ) );
 
 		// Clean up.
 		$this->assertTrue( remove_all_filters( 'filter_meta_box_custom_fields', 20 ) );

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -68,7 +68,8 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	}
 
 	/**
-	 * Test get_custom_fields_values() should return post meta from database when meta key exists in custom fields config.
+	 * Test get_custom_fields_values() should return post meta from database when meta key exists in custom fields
+	 * config.
 	 */
 	public function test_should_return_post_meta_from_database_when_meta_key_exists_in_custom_fields_config() {
 		$config = [

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/getCustomFieldsValues.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Tests for the function get_custom_fields_values().
+ *
+ * @package     spiralWebDb\centralHub\Tests\Integration\Metadata
+ * @since       1.3.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Integration\Metadata;
+
+use function KnowTheCode\ConfigStore\loadConfig;
+use function get_post_meta;
+use function add_post_meta;
+use function spiralWebDB\Metadata\get_custom_fields_values;
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+
+/**
+ * Class Tests_GetCustomFieldsValues
+ *
+ * @package spiralWebDb\centralHub\Tests\Integration\Metadata
+ * @group   meta-data
+ */
+class Tests_GetCustomFieldsValues extends Test_Case {
+
+	/**
+	 * Instance of the post object for each test.
+	 *
+	 * @var WP_Post
+	 */
+	protected $post;
+
+	/**
+	 * Empty the store before starting these tests.
+	 */
+	public static function setUpBeforeClass() {
+		self::empty_the_store();
+	}
+
+	/**
+	 * Set up each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Create and get the post_id via the factory method.
+		$this->post = self::factory()->post->create();
+	}
+
+	/**
+	 * Test get_custom_fields_values() should return an empty array when config store is empty.
+	 */
+	public function test_should_return_empty_array_when_config_store_is_empty() {
+		$config = [
+			'custom_fields' => [],
+		];
+
+		$this->assertSame( [], get_custom_fields_values( $this->post, 'events', $config ) );
+	}
+
+	/**
+	 * Test get_custom_fields_values() should return post meta from the database when post meta key exists.
+	 */
+	public function test_should_return_post_meta_from_database_when_post_meta_key_exists() {
+		$config = [
+			'meta_box.events' => [
+				'custom_fields' => [
+					'event-date' => '',
+					'event-time' => '',
+					'venue-name' => '',
+				]
+			],
+		];
+		foreach ( $config as $store_key => $config_to_store ) {
+			loadConfig( 'meta_box.events', $config['meta_box.events'] );
+		}
+//		var_dump( getConfig( 'meta_box.events' ) );
+		// Add post meta to the database so we have something to call.
+		add_post_meta( $this->post, 'event-date', '10-04-2019' );
+		add_post_meta( $this->post, 'event-time', '19:30:00' );
+		add_post_meta( $this->post, 'venue-name', 'Carnegie Hall' );
+
+		// Check database that post meta was added.
+		$this->assertSame( '10-04-2019', get_post_meta( $this->post, 'event-date', true ) );
+		$this->assertSame( '19:30:00', get_post_meta( $this->post, 'event-time', true ) );
+		$this->assertSame( 'Carnegie Hall', get_post_meta( $this->post, 'venue-name', true ) );
+
+		$expected = [
+			'meta_box.events' => [
+				'custom_fields' => [
+					'event-date' => '10-04-2019',
+					'event-time' => '19:30:00',
+					'venue-name' => 'Carnegie Hall',
+				]
+			],
+		];
+
+		$this->assertSame( $expected['meta_box.events'], get_custom_fields_values( $this->post, 'events', $config ) );
+	}
+
+	// Test get_custom_fields_values() should return default value from meta box config when post meta key does not exist.
+}


### PR DESCRIPTION
## PR Summary

`get_custom_fields_values()` is a helper function called from `render_meta_box()` within the meta box generator of the Central Hub plugin. The latter function runs the business logic to populate the custom fields (post meta box) view in the WP admin. 

`get_custom_fields_values()` returns the filter `filter_meta_box_custom_fields` and 3 arguments (`$custom_fields`, `$meta_box_id`, and `$post_id` ). The filter allows the custom field values stored in the database to be modified before they are rendered to the metabox on the admin screen. 

The file path to `get_custom_fields_values()` (relative to the root of it's Git repo) is: 

>`wp-content/mu-plugins/central-hub/src/meta-data/helpers.php`.

This PR contains the _integration_ tests with WordPress for `get_custom_fields_values()`.
