### PR TITLE
PR #44 (add/getCustomFieldsValues) | unit tests only

### DIFF
--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -32,6 +32,13 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 	protected $post;
 
 	/**
+	 * Configuration array property for custom fields. 
+	 *
+	 * @var array
+	 */
+	protected $config;
+
+	/**
 	 * Prepares the test environment before each test.
 	 */
 	protected function setUp() {

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Tests for the function get_custom_fields_values().
+ *
+ * @package     spiralWebDb\centralHub\Tests\Unit\Metadata
+ * @since       1.3.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\centralHub\Tests\Unit\Metadata;
+
+use Mockery as m;
+use Brain\Monkey;
+use function spiralWebDB\Metadata\get_custom_fields_values;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_GetCustomFieldsValues
+ *
+ * @package spiralWebDb\centralHub\Tests\Unit\Metadata
+ * @group   meta-data
+ */
+class Tests_GetCustomFieldsValues extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once CENTRAL_HUB_ROOT_DIR . '/src/meta-data/helpers.php';
+
+		$this->post     = m::mock( 'WP_Post' );
+		$this->post->ID = 99;
+	}
+
+	/**
+	 * Test get_custom_fields_values() should return an empty array when custom fields config is empty.
+	 */
+	public function test_should_return_empty_array_when_custom_fields_config_is_empty() {
+		$config = [
+			'custom_fields' => [],
+		];
+
+		$this->assertSame( [], get_custom_fields_values( $this->post, 'events', $config ) );
+	}
+
+	/**
+	 * Test get_custom_fields_values() should return post meta from database when meta key exists in custom fields
+	 * config.
+	 */
+	public function test_should_return_post_meta_from_database_when_meta_key_exists_in_custom_fields_config() {
+		$config = [
+			'custom_fields' => [
+				'event-date' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'event-time' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'venue-name' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+			],
+		];
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $this->post, 'event-date', $config['custom_fields']['event-date']['is_single'] )
+			->andReturn( '10-26-2019' );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $this->post, 'event-time', $config['custom_fields']['event-time']['is_single'] )
+			->andReturn( '19:30:00' );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $this->post, 'venue-name', $config['custom_fields']['venue-name']['is_single'] )
+			->andReturn( 'Carnegie Hall' );
+
+		$expected_custom_fields = [
+			'event-date' => '10-26-2019',
+			'event-time' => '19:30:00',
+			'venue-name' => 'Carnegie Hall',
+		];
+
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
+	}
+
+//	/**
+//	 * Test get_custom_fields_values() should return custom fields default values when post meta is not in database.
+//	 */
+//	public function test_should_return_custom_fields_default_values_when_post_meta_is_not_in_database() {
+//		// Check that database does not contain post meta.
+//		$this->assertSame( '', get_post_meta( $this->post, 'event-date', true ) );
+//		$this->assertSame( '', get_post_meta( $this->post, 'event-time', true ) );
+//		$this->assertSame( '', get_post_meta( $this->post, 'venue-name', true ) );
+//
+//		$expected_custom_fields = [
+//			'event-date' => '',
+//			'event-time' => '',
+//			'venue-name' => '',
+//		];
+//
+//		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $this->config ) );
+//	}
+//
+//	/**
+//	 * Test get_custom_fields_values() should return filtered custom field values.
+//	 */
+//	public function test_should_return_filtered_custom_field_values() {
+//		// Add post meta to the database so we have something to call.
+//		add_post_meta( $this->post, 'event-date', '10-12-2019' );
+//		add_post_meta( $this->post, 'event-time', '19:30:00' );
+//		add_post_meta( $this->post, 'venue-name', 'Carnegie Hall' );
+//
+//		// Check database that post meta was added.
+//		$this->assertSame( '10-12-2019', get_post_meta( $this->post, 'event-date', true ) );
+//		$this->assertSame( '19:30:00', get_post_meta( $this->post, 'event-time', true ) );
+//		$this->assertSame( 'Carnegie Hall', get_post_meta( $this->post, 'venue-name', true ) );
+//
+//		// Register custom callback to filter $tag with priority of 20 and 3 available arguments.
+//		add_filter( 'filter_meta_box_custom_fields', [ $this, 'filter_custom_field_values' ], 20, 3 );
+//		$this->assertTrue( has_filter( 'filter_meta_box_custom_fields' ) );
+//		$this->assertEquals( 20, has_filter( 'filter_meta_box_custom_fields', [ $this, 'filter_custom_field_values' ] ) );
+//
+//		$updated_custom_fields = [
+//			'event-date' => '10-19-2019',
+//			'event-time' => '15:00:00',
+//			'venue-name' => 'The Fabulous Fox Theater',
+//		];
+//		$this->assertSame( $updated_custom_fields, get_custom_fields_values( $this->post, 'events', $this->config ) );
+//
+//		// Clean up.
+//		remove_all_filters( 'filter_meta_box_custom_fields', 20 );
+//		delete_post_meta( $this->post, 'event-date' );
+//		delete_post_meta( $this->post, 'event-time' );
+//		delete_post_meta( $this->post, 'venue-name' );
+//	}
+//
+//	/*
+//	 * Filter the custom field values with a custom callback.
+//	 *
+//	 * @param array  $custom_fields Array of custom fields values
+//	 * @param string $meta_box_id   Meta box's key (ID) - used to identify this meta box
+//	 * @param int    $post_id       Post's ID
+//	 * @return array Updated custom fields values.
+//	 */
+//	public function filter_custom_field_values( $custom_fields, $meta_box_id, $post_id ) {
+//		$args          = func_get_args();
+//		$expected_args = [
+//			[
+//				'event-date' => '10-12-2019',
+//				'event-time' => '19:30:00',
+//				'venue-name' => 'Carnegie Hall',
+//			],
+//			'events',
+//			$this->post,
+//		];
+//
+//		// Test that the callback received the 3 arguments and the values are as expected.
+//		$this->assertCount( 3, $args );
+//		$this->assertSame( $expected_args, $args );
+//
+//		// Modify the custom field values.
+//		$custom_fields['event-date'] = '10-19-2019';
+//		$custom_fields['event-time'] = '15:00:00';
+//		$custom_fields['venue-name'] = 'The Fabulous Fox Theater';
+//
+//		return $custom_fields;
+//	}
+}

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -70,15 +70,15 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 		];
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post, 'event-date', $config['custom_fields']['event-date']['is_single'] )
+			->with( $this->post->ID, 'event-date', $config['custom_fields']['event-date']['is_single'] )
 			->andReturn( '10-26-2019' );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post, 'event-time', $config['custom_fields']['event-time']['is_single'] )
+			->with( $this->post->ID, 'event-time', $config['custom_fields']['event-time']['is_single'] )
 			->andReturn( '19:30:00' );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post, 'venue-name', $config['custom_fields']['venue-name']['is_single'] )
+			->with( $this->post->ID, 'venue-name', $config['custom_fields']['venue-name']['is_single'] )
 			->andReturn( 'Carnegie Hall' );
 
 		$expected_custom_fields = [

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -25,6 +25,13 @@ use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 class Tests_GetCustomFieldsValues extends Test_Case {
 
 	/**
+	 * Instance of the post object for each test.
+	 *
+	 * @var WP_Post
+	 */
+	protected $post;
+
+	/**
 	 * Prepares the test environment before each test.
 	 */
 	protected function setUp() {

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -64,17 +64,33 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 				],
 			],
 		];
+	}
+
+	/**
+	 * Test get_custom_fields_values() should return an empty array when custom fields config is empty.
+	 */
+	public function test_should_return_empty_array_when_custom_fields_config_is_empty() {
+		$this->config = [ 'custom_fields' => [] ];
+
+		$this->assertSame( [], get_custom_fields_values( $this->post->ID, 'events', $this->config ) );
+	}
+
+	/**
+	 * Test get_custom_fields_values() should return post meta from database when meta key exists in custom fields
+	 * config.
+	 */
+	public function test_should_return_post_meta_from_database_when_meta_key_exists_in_custom_fields_config() {
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post->ID, 'event-date', $config['custom_fields']['event-date']['is_single'] )
+			->with( $this->post->ID, 'event-date', $this->config['custom_fields']['event-date']['is_single'] )
 			->andReturn( '10-26-2019' );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post->ID, 'event-time', $config['custom_fields']['event-time']['is_single'] )
+			->with( $this->post->ID, 'event-time', $this->config['custom_fields']['event-time']['is_single'] )
 			->andReturn( '19:30:00' );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post->ID, 'venue-name', $config['custom_fields']['venue-name']['is_single'] )
+			->with( $this->post->ID, 'venue-name', $this->config['custom_fields']['venue-name']['is_single'] )
 			->andReturn( 'Carnegie Hall' );
 
 		$expected_custom_fields = [

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -87,26 +87,48 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			'venue-name' => 'Carnegie Hall',
 		];
 
-		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $config ) );
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $config ) );
 	}
 
-//	/**
-//	 * Test get_custom_fields_values() should return custom fields default values when post meta is not in database.
-//	 */
-//	public function test_should_return_custom_fields_default_values_when_post_meta_is_not_in_database() {
-//		// Check that database does not contain post meta.
-//		$this->assertSame( '', get_post_meta( $this->post, 'event-date', true ) );
-//		$this->assertSame( '', get_post_meta( $this->post, 'event-time', true ) );
-//		$this->assertSame( '', get_post_meta( $this->post, 'venue-name', true ) );
-//
-//		$expected_custom_fields = [
-//			'event-date' => '',
-//			'event-time' => '',
-//			'venue-name' => '',
-//		];
-//
-//		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post, 'events', $this->config ) );
-//	}
+	/**
+	 * Test get_custom_fields_values() should return custom fields default values when post meta is not in database.
+	 */
+	public function test_should_return_custom_fields_default_values_when_post_meta_is_not_in_database() {
+		$config = [
+			'custom_fields' => [
+				'event-date' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'event-time' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'venue-name' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+			],
+		];
+
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->andReturn( $config['custom_fields']['event-date']['default'] );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->andReturn( $config['custom_fields']['event-time']['default'] );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->andReturn( $config['custom_fields']['venue-name']['default'] );
+
+		$expected_custom_fields = [
+			'event-date' => '',
+			'event-time' => '',
+			'venue-name' => '',
+		];
+
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $config ) );
+	}
 //
 //	/**
 //	 * Test get_custom_fields_values() should return filtered custom field values.

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -136,69 +136,52 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 
 		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $config ) );
 	}
-//
-//	/**
-//	 * Test get_custom_fields_values() should return filtered custom field values.
-//	 */
-//	public function test_should_return_filtered_custom_field_values() {
-//		// Add post meta to the database so we have something to call.
-//		add_post_meta( $this->post, 'event-date', '10-12-2019' );
-//		add_post_meta( $this->post, 'event-time', '19:30:00' );
-//		add_post_meta( $this->post, 'venue-name', 'Carnegie Hall' );
-//
-//		// Check database that post meta was added.
-//		$this->assertSame( '10-12-2019', get_post_meta( $this->post, 'event-date', true ) );
-//		$this->assertSame( '19:30:00', get_post_meta( $this->post, 'event-time', true ) );
-//		$this->assertSame( 'Carnegie Hall', get_post_meta( $this->post, 'venue-name', true ) );
-//
-//		// Register custom callback to filter $tag with priority of 20 and 3 available arguments.
-//		add_filter( 'filter_meta_box_custom_fields', [ $this, 'filter_custom_field_values' ], 20, 3 );
-//		$this->assertTrue( has_filter( 'filter_meta_box_custom_fields' ) );
-//		$this->assertEquals( 20, has_filter( 'filter_meta_box_custom_fields', [ $this, 'filter_custom_field_values' ] ) );
-//
-//		$updated_custom_fields = [
-//			'event-date' => '10-19-2019',
-//			'event-time' => '15:00:00',
-//			'venue-name' => 'The Fabulous Fox Theater',
-//		];
-//		$this->assertSame( $updated_custom_fields, get_custom_fields_values( $this->post, 'events', $this->config ) );
-//
-//		// Clean up.
-//		remove_all_filters( 'filter_meta_box_custom_fields', 20 );
-//		delete_post_meta( $this->post, 'event-date' );
-//		delete_post_meta( $this->post, 'event-time' );
-//		delete_post_meta( $this->post, 'venue-name' );
-//	}
-//
-//	/*
-//	 * Filter the custom field values with a custom callback.
-//	 *
-//	 * @param array  $custom_fields Array of custom fields values
-//	 * @param string $meta_box_id   Meta box's key (ID) - used to identify this meta box
-//	 * @param int    $post_id       Post's ID
-//	 * @return array Updated custom fields values.
-//	 */
-//	public function filter_custom_field_values( $custom_fields, $meta_box_id, $post_id ) {
-//		$args          = func_get_args();
-//		$expected_args = [
-//			[
-//				'event-date' => '10-12-2019',
-//				'event-time' => '19:30:00',
-//				'venue-name' => 'Carnegie Hall',
-//			],
-//			'events',
-//			$this->post,
-//		];
-//
-//		// Test that the callback received the 3 arguments and the values are as expected.
-//		$this->assertCount( 3, $args );
-//		$this->assertSame( $expected_args, $args );
-//
-//		// Modify the custom field values.
-//		$custom_fields['event-date'] = '10-19-2019';
-//		$custom_fields['event-time'] = '15:00:00';
-//		$custom_fields['venue-name'] = 'The Fabulous Fox Theater';
-//
-//		return $custom_fields;
-//	}
+
+	/**
+	 * Test get_custom_fields_values() should return custom field values passed through filter.
+	 */
+	public function test_should_return_custom_field_values_passed_through_filter() {
+		$config = [
+			'custom_fields' => [
+				'event-date' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'event-time' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+				'venue-name' => [
+					'is_single' => true,
+					'default'   => '',
+				],
+			],
+		];
+
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $this->post->ID, 'event-date', $config['custom_fields']['event-date']['is_single'] )
+			->andReturn( '10-26-2019' );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $this->post->ID, 'event-time', $config['custom_fields']['event-time']['is_single'] )
+			->andReturn( '19:30:00' );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $this->post->ID, 'venue-name', $config['custom_fields']['venue-name']['is_single'] )
+			->andReturn( 'Carnegie Hall' );
+
+		$expected_custom_fields = [
+			'event-date' => '10-26-2019',
+			'event-time' => '19:30:00',
+			'venue-name' => 'Carnegie Hall',
+		];
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'filter_meta_box_custom_fields', $expected_custom_fields, 'events', $this->post->ID )
+			->andReturn( $expected_custom_fields );
+
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $config ) );
+	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -48,25 +48,7 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 
 		$this->post     = m::mock( 'WP_Post' );
 		$this->post->ID = 99;
-	}
-
-	/**
-	 * Test get_custom_fields_values() should return an empty array when custom fields config is empty.
-	 */
-	public function test_should_return_empty_array_when_custom_fields_config_is_empty() {
-		$config = [
-			'custom_fields' => [],
-		];
-
-		$this->assertSame( [], get_custom_fields_values( $this->post->ID, 'events', $config ) );
-	}
-
-	/**
-	 * Test get_custom_fields_values() should return post meta from database when meta key exists in custom fields
-	 * config.
-	 */
-	public function test_should_return_post_meta_from_database_when_meta_key_exists_in_custom_fields_config() {
-		$config = [
+		$this->config = [
 			'custom_fields' => [
 				'event-date' => [
 					'is_single' => true,

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -51,7 +51,7 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			'custom_fields' => [],
 		];
 
-		$this->assertSame( [], get_custom_fields_values( $this->post, 'events', $config ) );
+		$this->assertSame( [], get_custom_fields_values( $this->post->ID, 'events', $config ) );
 	}
 
 	/**

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/getCustomFieldsValues.php
@@ -99,39 +99,22 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			'venue-name' => 'Carnegie Hall',
 		];
 
-		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $config ) );
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $this->config ) );
 	}
 
 	/**
 	 * Test get_custom_fields_values() should return custom fields default values when post meta is not in database.
 	 */
 	public function test_should_return_custom_fields_default_values_when_post_meta_is_not_in_database() {
-		$config = [
-			'custom_fields' => [
-				'event-date' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'event-time' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'venue-name' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-			],
-		];
-
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->andReturn( $config['custom_fields']['event-date']['default'] );
+			->andReturn( $this->config['custom_fields']['event-date']['default'] );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->andReturn( $config['custom_fields']['event-time']['default'] );
+			->andReturn( $this->config['custom_fields']['event-time']['default'] );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->andReturn( $config['custom_fields']['venue-name']['default'] );
+			->andReturn( $this->config['custom_fields']['venue-name']['default'] );
 
 		$expected_custom_fields = [
 			'event-date' => '',
@@ -139,41 +122,24 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			'venue-name' => '',
 		];
 
-		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $config ) );
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $this->config ) );
 	}
 
 	/**
 	 * Test get_custom_fields_values() should return custom field values passed through filter.
 	 */
 	public function test_should_return_custom_field_values_passed_through_filter() {
-		$config = [
-			'custom_fields' => [
-				'event-date' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'event-time' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-				'venue-name' => [
-					'is_single' => true,
-					'default'   => '',
-				],
-			],
-		];
-
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post->ID, 'event-date', $config['custom_fields']['event-date']['is_single'] )
+			->with( $this->post->ID, 'event-date', $this->config['custom_fields']['event-date']['is_single'] )
 			->andReturn( '10-26-2019' );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post->ID, 'event-time', $config['custom_fields']['event-time']['is_single'] )
+			->with( $this->post->ID, 'event-time', $this->config['custom_fields']['event-date']['is_single'] )
 			->andReturn( '19:30:00' );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->post->ID, 'venue-name', $config['custom_fields']['venue-name']['is_single'] )
+			->with( $this->post->ID, 'venue-name', $this->config['custom_fields']['event-date']['is_single'] )
 			->andReturn( 'Carnegie Hall' );
 
 		$expected_custom_fields = [
@@ -187,6 +153,6 @@ class Tests_GetCustomFieldsValues extends Test_Case {
 			->with( 'filter_meta_box_custom_fields', $expected_custom_fields, 'events', $this->post->ID )
 			->andReturn( $expected_custom_fields );
 
-		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $config ) );
+		$this->assertSame( $expected_custom_fields, get_custom_fields_values( $this->post->ID, 'events', $this->config ) );
 	}
 }


### PR DESCRIPTION
## PR Summary

`get_custom_fields_values()` is a helper function called from `render_meta_box()` within the meta box generator of the Central Hub plugin. The latter function runs the business logic to populate the custom fields (post meta box) view in the WP admin.

`get_custom_fields_values()` returns the filter `'filter_meta_box_custom_fields'` and 3 arguments ($custom_fields, $meta_box_id, and $post_id ). The filter allows the custom field values stored in the database to be modified before they are rendered to the metabox on the admin screen.

The file path to get_custom_fields_values() (relative to the root of it's Git repo) is:

>`wp-content/mu-plugins/central-hub/src/meta-data/helpers.php`.

This PR contains the _unit tests_ for `get_custom_fields_values()`.