### PR TITLE
Loads minified stylesheet. Adds theme utility functions.

### DIFF
--- a/themes/developers/functions.php
+++ b/themes/developers/functions.php
@@ -5,7 +5,7 @@
  * @package     spiralWebDB\Developers
  * @since       1.0.2
  * @author      Robert A. Gadon
- * @link        https://knowthecode.io
+ * @link        https://spiralwebdb.com
  * @license     GNU General Public License 2.0+
  */
 namespace spiralWebDB\Developers;

--- a/themes/developers/functions.php
+++ b/themes/developers/functions.php
@@ -10,6 +10,6 @@
  */
 namespace spiralWebDB\Developers;
 
-include_once( 'lib/init.php' );
+include_once 'lib/init.php';
 
-include_once( 'lib/functions/autoload.php' );
+include_once 'lib/functions/autoload.php';

--- a/themes/developers/functions.php
+++ b/themes/developers/functions.php
@@ -10,6 +10,68 @@
  */
 namespace spiralWebDB\Developers;
 
+/**
+ * Get the absolute path to the root directory of the child theme.
+ *
+ * @since 1.0.0
+ *
+ * @return string returns the directory path.
+ */
+function get_theme_dir() {
+	return __DIR__;
+}
+
+/**
+ * Get the URL to the root of the child theme.
+ *
+ * @since 1.0.0
+ *
+ * @return string returns the URL to the root of the child theme.
+ */
+function get_theme_url() {
+	static $url = '';
+
+	if ( empty( $url ) ) {
+		$url = get_stylesheet_directory_uri();
+	}
+
+	return $url;
+}
+
+/**
+ * Get the theme's version.
+ *
+ * @since 1.0.0
+ *
+ * @return string returns the theme's version.
+ */
+function get_theme_version() {
+	static $version = null;
+
+	if ( null !== $version ) {
+		return $version;
+	}
+
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		$version = filemtime( __DIR__ . '/style.min.css' );
+	} else {
+		$version = ( wp_get_theme() )->get( 'Version' );
+	}
+
+	return $version;
+}
+
+/**
+ * Checks if in a debug/dev environment.
+ *
+ * @since 1.0.0
+ *
+ * @return bool
+ */
+function is_in_debug() {
+	return defined( 'WP_DEBUG' ) && WP_DEBUG;
+}
+
 include_once 'lib/init.php';
 
 include_once 'lib/functions/autoload.php';

--- a/themes/developers/functions.php
+++ b/themes/developers/functions.php
@@ -3,7 +3,7 @@
  * Developer's Theme
  *
  * @package     spiralWebDB\Developers
- * @since       1.0.2
+ * @since       2.0.0
  * @author      Robert A. Gadon
  * @link        https://spiralwebdb.com
  * @license     GNU General Public License 2.0+
@@ -13,7 +13,7 @@ namespace spiralWebDB\Developers;
 /**
  * Get the absolute path to the root directory of the child theme.
  *
- * @since 1.0.0
+ * @since 2.0.0
  *
  * @return string returns the directory path.
  */
@@ -24,7 +24,7 @@ function get_theme_dir() {
 /**
  * Get the URL to the root of the child theme.
  *
- * @since 1.0.0
+ * @since 2.0.0
  *
  * @return string returns the URL to the root of the child theme.
  */
@@ -41,7 +41,7 @@ function get_theme_url() {
 /**
  * Get the theme's version.
  *
- * @since 1.0.0
+ * @since 2.0.0
  *
  * @return string returns the theme's version.
  */
@@ -64,7 +64,7 @@ function get_theme_version() {
 /**
  * Checks if in a debug/dev environment.
  *
- * @since 1.0.0
+ * @since 2.0.0
  *
  * @return bool
  */

--- a/themes/developers/lib/functions/load-assets.php
+++ b/themes/developers/lib/functions/load-assets.php
@@ -39,12 +39,12 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
  */
 function enqueue_assets() {
 
-	wp_enqueue_style( CHILD_TEXT_DOMAIN . '-fonts', '//fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700', array(), CHILD_THEME_VERSION );
-	wp_enqueue_style( CHILD_TEXT_DOMAIN . '-fonts', '//fonts.googleapis.com/css?family=Lato:300,400,400i,700,700i', array(), CHILD_THEME_VERSION );
+	wp_enqueue_style( CHILD_TEXT_DOMAIN . '-fonts', '//fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700', array(), get_theme_version() );
+	wp_enqueue_style( CHILD_TEXT_DOMAIN . '-fonts', '//fonts.googleapis.com/css?family=Lato:300,400,400i,700,700i', array(), get_theme_version() );
 	wp_enqueue_style( 'font-awesome-free', '//use.fontawesome.com/releases/v5.1.0/css/all.css' );
 	wp_enqueue_style( 'dashicons' );
 
-	wp_enqueue_script( CHILD_TEXT_DOMAIN . '-responsive-menu', get_theme_url() . '/assets/js/responsive-menu.js', array( 'jquery' ), CHILD_THEME_VERSION, true );
+	wp_enqueue_script( CHILD_TEXT_DOMAIN . '-responsive-menu', get_theme_url() . '/assets/js/responsive-menu.js', array( 'jquery' ), get_theme_version(), true );
 
 	$localized_script_args = array(
 		'mainMenu' => __( 'Menu', CHILD_TEXT_DOMAIN ),

--- a/themes/developers/lib/functions/load-assets.php
+++ b/themes/developers/lib/functions/load-assets.php
@@ -33,7 +33,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 /**
  * Enqueue Scripts and Styles.
  *
- * @since 1.0.2
+ * @since 2.0.0
  *
  * @return void
  */

--- a/themes/developers/lib/functions/load-assets.php
+++ b/themes/developers/lib/functions/load-assets.php
@@ -11,6 +11,24 @@
 
 namespace spiralWebDB\Developers;
 
+add_filter( 'stylesheet_uri', __NAMESPACE__ . '\change_stylesheet_uri_to_min' );
+/**
+ * Change the stylesheet to the minified version.
+ *
+ * @since 2.0.0
+ *
+ * @param string $stylesheet_uri Stylesheet's URI.
+ *
+ * @return string
+ */
+function change_stylesheet_uri_to_min( $stylesheet_uri ) {
+	if ( is_in_debug() ) {
+		return $stylesheet_uri;
+	}
+
+	return get_theme_url() . '/style.min.css';
+}
+
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 /**
  * Enqueue Scripts and Styles.

--- a/themes/developers/lib/functions/load-assets.php
+++ b/themes/developers/lib/functions/load-assets.php
@@ -5,7 +5,7 @@
  * @package     spiralWebDB\Developers
  * @since       1.0.0
  * @author      Robert A. Gadon
- * @link        https://knowthecode.io
+ * @link        https://spiralwebdb.com
  * @license     GNU General Public License 2.0+
  */
 

--- a/themes/developers/lib/functions/load-assets.php
+++ b/themes/developers/lib/functions/load-assets.php
@@ -44,7 +44,7 @@ function enqueue_assets() {
 	wp_enqueue_style( 'font-awesome-free', '//use.fontawesome.com/releases/v5.1.0/css/all.css' );
 	wp_enqueue_style( 'dashicons' );
 
-	wp_enqueue_script( CHILD_TEXT_DOMAIN . '-responsive-menu', CHILD_URL . '/assets/js/responsive-menu.js', array( 'jquery' ), CHILD_THEME_VERSION, true );
+	wp_enqueue_script( CHILD_TEXT_DOMAIN . '-responsive-menu', get_theme_url() . '/assets/js/responsive-menu.js', array( 'jquery' ), CHILD_THEME_VERSION, true );
 
 	$localized_script_args = array(
 		'mainMenu' => __( 'Menu', CHILD_TEXT_DOMAIN ),


### PR DESCRIPTION
This PR adds the ability to load the minified stylesheet when not in debug. Why? For performance. In production, the `style.min.css` is smaller and will download to the browser faster, resulting in faster performance.

To make this code work, this PR also adds the following utility functions to the theme's `functions.php` file:

- `get_theme_dir()`
- `get_theme_url()`
- `get_theme_version()`
- `is_in_debug()`

These functions replace constants and reduce coupling to Genesis.