### PR TITLE
Fixes gulp watch in theme.

### DIFF
--- a/themes/developers/dev/gulpfile.js/config.js
+++ b/themes/developers/dev/gulpfile.js/config.js
@@ -10,6 +10,7 @@ module.exports = {
 		sass: devDir + 'assets/sass/style.scss',
 		src: rootDir + 'style.css',
 		dest: rootDir,
+		watch: devDir + 'assets/sass/**/*.scss',
 		sassOptions: {
 			outputStyle: 'expanded',
 			indentType: 'tab',

--- a/themes/developers/dev/gulpfile.js/index.js
+++ b/themes/developers/dev/gulpfile.js/index.js
@@ -15,5 +15,5 @@ module.exports.lintStyles = stylesTasks.stylelint;
  * Let's watch everything by running: `gulp watch`.
  */
 module.exports.watch = () => {
-	gulp.watch(config.styles.sass, stylesTasks.styles);
+	gulp.watch(config.styles.watch, stylesTasks.styles);
 }


### PR DESCRIPTION
Adds a `watch` parameter to the `config.js` to specify which Sass folder and subfolders to watch for changes.