### PR TITLE
PR #54 (update/extend-give-wp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /plugins/give-recurring
 /plugins/give-stripe
 /plugins/give-tributes
+/plugins/google-site-kit
 /plugins/jetpack
 /plugins/members
 /plugins/members-role-hierarchy
@@ -35,6 +36,7 @@
 /plugins/wordpress-seo
 /plugins/wp-migrate-db-pro
 /plugins/wp-migrate-db-pro-media-files
+/plugins/wp-migrate-db-pro-theme-plugin-files
 /themes/Beans
 /themes/genesis
 /upgrade

--- a/plugins/extend-give-wp/CHANGELOG.md
+++ b/plugins/extend-give-wp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1
+
+- Register the plugin with the Custom module in the `central-hub` plugin to flush the rewrite rules on plugin status change (activation, deactivation, uninstall).
+- Update plugin README.md file. 
+
 ## 1.0.0
 
 Initial release.

--- a/plugins/extend-give-wp/README.md
+++ b/plugins/extend-give-wp/README.md
@@ -4,9 +4,11 @@
 
 This plugin extends the <a href="givewp.com">GiveWP donation plugin</a> by: 
 
-(1) registering custom functions to it's actions hooks, 
+(1) registering custom functions to the GiveWP plugin's actions hooks, 
+
 (2) setting an option in the WordPress database to store and retrieve the featured image post ID displayed in the Give donation form, and
-(3) registering `extend-give-wp` with the Custom module of the `central-hub` plugin to to flush the rewrite rules on plugin status change (activation, deactivation, uninstall);
+
+(3) registering `extend-give-wp` with the Custom module of the `central-hub` plugin to flush the rewrite rules on plugin status change ( activation, deactivation, uninstall );
 
 This plugin's structure is modeled on the <a href="https://github.com/KnowTheCode/Sandbox-Workspace">`Sandbox-Workspace` plugin,</a> 
 which is also available from the <a href="https://github.com/KnowTheCode">KnowtheCode.io code repository on GitHub.com</a>.

--- a/plugins/extend-give-wp/README.md
+++ b/plugins/extend-give-wp/README.md
@@ -2,11 +2,14 @@
 
 ## Purpose
 
-This plugin extends the <a href="givewp.com">GiveWP donation plugin</a> by (1) registering custom functions to it's hooks (actions and filters), and 
-(2) settings an option in the WordPress database to store and retrieve the donation form featured image post ID. 
+This plugin extends the <a href="givewp.com">GiveWP donation plugin</a> by: 
 
-The plugin structure is modeled on the <a href="https://github.com/KnowTheCode/Sandbox-Workspace">`Sandbox-Workspace` plugin</a> 
-available from the <a href="https://github.com/KnowTheCode">KnowtheCode.io code repository on GitHub.com</a>.
+(1) registering custom functions to it's actions hooks, 
+(2) setting an option in the WordPress database to store and retrieve the featured image post ID displayed in the Give donation form, and
+(3) registering `extend-give-wp` with the Custom module of the `central-hub` plugin to to flush the rewrite rules on plugin status change (activation, deactivation, uninstall);
+
+This plugin's structure is modeled on the <a href="https://github.com/KnowTheCode/Sandbox-Workspace">`Sandbox-Workspace` plugin,</a> 
+which is also available from the <a href="https://github.com/KnowTheCode">KnowtheCode.io code repository on GitHub.com</a>.
 
 ## Application
 

--- a/plugins/extend-give-wp/bootstrap.php
+++ b/plugins/extend-give-wp/bootstrap.php
@@ -9,8 +9,8 @@
  * @wordpress-plugin
  * Plugin Name: Extend GiveWP
  * Plugin URI:  https://github.com/rgadon107/cornerstone/plugins/extend-give-wp/
- * Description: This plugin extends the Give donation plugin by registering custom functions to it's hooks.
- * Version:     1.0.0
+ * Description: Extends the GiveWP donation plugin by rendering added custom content to the donation form.
+ * Version:     1.0.1
  * Author:      Robert A. Gadon
  * Author URI:  https://spiralwebdb.com
  * Text Domain: extend-give

--- a/plugins/extend-give-wp/bootstrap.php
+++ b/plugins/extend-give-wp/bootstrap.php
@@ -20,6 +20,8 @@
 
 namespace spiralWebDB\ExtendGiveWP;
 
+use spiralWebDb\Module\Custom;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -53,4 +55,17 @@ function autoload_files() {
 	}
 }
 
-autoload_files();
+/**
+ * Launch the plugin.
+ *
+ * @since 1.0.0
+ *
+ * @return void
+ */
+function launch() {
+	autoload_files();
+
+	Custom\register_plugin( __FILE__ );
+}
+
+launch();


### PR DESCRIPTION
## PR Summary

This branch updates the `extend-give-wp` plugin to version 1.0.1. From the plugin CHANGELOG.md file: 

- Register the plugin with the Custom module in the `central-hub` plugin to flush the rewrite rules on plugin status change ( activation, deactivation, uninstall ).
- Update plugin README.md file. 