### PR TITLE
PR#59 (addDescriptionBeneathPostTitle)

### DIFF
--- a/plugins/tours/src/admin/edit-form-advanced.php
+++ b/plugins/tours/src/admin/edit-form-advanced.php
@@ -35,10 +35,12 @@ add_action( 'edit_form_before_permalink', __NAMESPACE__ . '\add_description_bene
  *
  * @since 1.0.0
  *
+ * @param WP_Post $post Post object.
+ *
  * @return void
  */
-function add_description_beneath_post_title() {
-	if ( 'tours' !== get_post_type() ) {
+function add_description_beneath_post_title( $post ) {
+	if ( 'tours' !== get_post_type( $post ) ) {
 		return;
 	}
 

--- a/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Tests for add_description_beneath_post_title().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use Brain\Monkey;
+use function spiralWebDb\CornerstoneTours\add_description_beneath_post_title;
+
+/**
+ * Class Tests_AddDescriptionBeneathPostTitle
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ * @group   admin
+ */
+class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
+
+	/**
+	 * Instance of the post object for each test.
+	 *
+	 * @var WP_Post
+	 */
+	protected $post;
+
+	/**
+	 * Set up each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * Clean up the test environment after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	/**
+	 * Test add_description_beneath_post_title() should return empty when post type is 'post'.
+	 */
+	public function test_should_return_empty_when_post_type_is_post() {
+		// Create and get the post ID for the 'post' post_type via factory method.
+		$post_id = self::factory()->post->create();
+		get_post_type( $post_id );
+
+		$this->assertEmpty( add_description_beneath_post_title() );
+	}
+
+	/**
+	 * Test add_description_beneath_post_title() should return string when post type is 'tours'.
+	 */
+	public function test_should_contain_string_when_post_type_is_tours() {
+		// Create and get the post ID and 'tours' post_type via the factory method.
+		$post_id = $this->factory()->post->create( [ 'post_type' => 'tours' ] );
+		get_post_type( $post_id );
+
+		$expected_view_html = <<<VIEW
+<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
+VIEW;
+
+		// Fire the function under test and grab the HTML out of the buffer.
+		ob_start();
+		Monkey\Functions\when( 'get_post_type' )->justReturn( 'tours' );
+		add_description_beneath_post_title();
+		$actual_html = ob_get_clean();
+
+		// Test the HTML
+		$this->assertContains( $expected_view_html, $actual_html );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
@@ -32,20 +32,6 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 	protected $post;
 
 	/**
-	 * Set up each test.
-	 */
-	public function setUp() {
-		parent::setUp();
-	}
-
-	/**
-	 * Clean up the test environment after each test.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-	}
-
-	/**
 	 * Test add_description_beneath_post_title() should return empty when post type is 'post'.
 	 */
 	public function test_should_return_empty_when_post_type_is_post() {

--- a/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
@@ -12,8 +12,6 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use Brain\Monkey;
-use function spiralWebDb\CornerstoneTours\add_description_beneath_post_title;
 
 /**
  * Class Tests_AddDescriptionBeneathPostTitle
@@ -25,43 +23,40 @@ use function spiralWebDb\CornerstoneTours\add_description_beneath_post_title;
 class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 
 	/**
-	 * Instance of the post object for each test.
-	 *
-	 * @var WP_Post
+	 * Test add_description_beneath_post_title() should npt contain view when the post type is 'post'.
 	 */
-	protected $post;
-
-	/**
-	 * Test add_description_beneath_post_title() should return empty when post type is 'post'.
-	 */
-	public function test_should_return_empty_when_post_type_is_post() {
-		// Create and get the post ID for the 'post' post_type via factory method.
-		$post_id = self::factory()->post->create();
-		get_post_type( $post_id );
-
-		$this->assertEmpty( add_description_beneath_post_title() );
-	}
-
-	/**
-	 * Test add_description_beneath_post_title() should return string when post type is 'tours'.
-	 */
-	public function test_should_contain_string_when_post_type_is_tours() {
-		// Create and get the post ID and 'tours' post_type via the factory method.
-		$post_id = $this->factory()->post->create( [ 'post_type' => 'tours' ] );
-		get_post_type( $post_id );
-
-		$expected_view_html = <<<VIEW
+	public function test_should_not_contain_view_when_post_type_is_post() {
+		// Create and get the post object for the 'post' post_type via the factory method.
+		$post = self::factory()->post->create_and_get();
+		$expected_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
 
-		// Fire the function under test and grab the HTML out of the buffer.
+		// Run the output buffer to fire the event to which the callback is registered.
 		ob_start();
-		Monkey\Functions\when( 'get_post_type' )->justReturn( 'tours' );
-		add_description_beneath_post_title();
+		do_action( 'edit_form_before_permalink', $post );
+		$actual_html = ob_get_clean();
+
+		$this->assertNotContains( $expected_html, $actual_html );
+	}
+
+	/**
+	 * Test add_description_beneath_post_title() should contain view when the post type is 'tours'.
+	 */
+	public function test_should_contain_view_when_post_type_is_tours() {
+		// Create and get the post object with 'tours' post_type via the factory method.
+		$post = $this->factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
+		$expected_html = <<<VIEW
+<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
+VIEW;
+
+		// Run the output buffer to fire the event to which the callback is registered.
+		ob_start();
+		do_action( 'edit_form_before_permalink', $post );
 		$actual_html = ob_get_clean();
 
 		// Test the HTML
-		$this->assertContains( $expected_view_html, $actual_html );
+		$this->assertSame( $expected_html, $actual_html );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
@@ -28,7 +28,7 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 	public function test_should_not_contain_view_when_post_type_is_post() {
 		// Create and get the post object for the 'post' post_type via the factory method.
 		$post = self::factory()->post->create_and_get();
-		$expected_html = <<<VIEW
+		$view_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
 
@@ -37,7 +37,7 @@ VIEW;
 		do_action( 'edit_form_before_permalink', $post );
 		$actual_html = ob_get_clean();
 
-		$this->assertNotContains( $expected_html, $actual_html );
+		$this->assertNotContains( $view_html, $actual_html );
 	}
 
 	/**
@@ -46,7 +46,7 @@ VIEW;
 	public function test_should_contain_view_when_post_type_is_tours() {
 		// Create and get the post object with 'tours' post_type via the factory method.
 		$post = $this->factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
-		$expected_html = <<<VIEW
+		$view_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
 
@@ -56,7 +56,7 @@ VIEW;
 		$actual_html = ob_get_clean();
 
 		// Test the HTML
-		$this->assertSame( $expected_html, $actual_html );
+		$this->assertSame( $view_html, $actual_html );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
@@ -11,7 +11,7 @@
 
 namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
-use Brain\Monkey\Functions;
+use Brain\Monkey;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\add_description_beneath_post_title;
 
@@ -37,7 +37,7 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 	 * Test add_description_beneath_post_title() should return empty when the post type is not 'tours'.
 	 */
 	public function test_should_return_empty_when_post_type_is_not_tours() {
-		Functions\expect( 'get_post_type' )
+		Monkey\Functions\expect( 'get_post_type' )
 			->once()
 			->andReturn( 'post' );
 
@@ -48,7 +48,7 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 	 * Test add_description_beneath_post_title() should return string when the post type is 'tours'.
 	 */
 	public function test_should_return_string_when_post_type_is_tours() {
-		Functions\expect( 'get_post_type' )
+		Monkey\Functions\expect( 'get_post_type' )
 			->once()
 			->andReturn( 'tours' );
 

--- a/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
@@ -40,7 +40,7 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 		Monkey\Functions\expect( 'get_post_type' )
 			->once()
 			->andReturn( 'post' );
-		$expected_html = <<<VIEW
+		$view_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
 
@@ -50,7 +50,7 @@ VIEW;
 		$actual_html = ob_get_clean();
 
 		$this->assertEmpty( $actual_html );
-		$this->assertNotContains( $expected_html, $actual_html );
+		$this->assertNotContains( $view_html, $actual_html );
 	}
 
 	/**
@@ -60,7 +60,7 @@ VIEW;
 		Monkey\Functions\expect( 'get_post_type' )
 			->once()
 			->andReturn( 'tours' );
-		$expected_html = <<<VIEW
+		$view_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
 
@@ -70,7 +70,7 @@ VIEW;
 		$actual_html = ob_get_clean();
 
 		// Test the HTML.
-		$this->assertSame( $expected_html, $actual_html );
+		$this->assertSame( $view_html, $actual_html );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
@@ -34,32 +34,43 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 	}
 
 	/**
-	 * Test add_description_beneath_post_title() should return empty when the post type is not 'tours'.
+	 * Test add_description_beneath_post_title() should npt contain view when the post type is 'post'.
 	 */
-	public function test_should_return_empty_when_post_type_is_not_tours() {
+	public function test_should_not_contain_view_when_post_type_is_post() {
 		Monkey\Functions\expect( 'get_post_type' )
 			->once()
 			->andReturn( 'post' );
-
-		$this->assertEmpty( add_description_beneath_post_title() );
-	}
-
-	/**
-	 * Test add_description_beneath_post_title() should return string when the post type is 'tours'.
-	 */
-	public function test_should_return_string_when_post_type_is_tours() {
-		Monkey\Functions\expect( 'get_post_type' )
-			->once()
-			->andReturn( 'tours' );
+		$expected_html = <<<VIEW
+<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
+VIEW;
 
 		// Fire the rendering function and grab the HTML out of the buffer.
 		ob_start();
-		add_description_beneath_post_title();
+		add_description_beneath_post_title( $post );
+		$actual_html = ob_get_clean();
+
+		$this->assertEmpty( $actual_html );
+		$this->assertNotContains( $expected_html, $actual_html );
+	}
+
+	/**
+	 * Test add_description_beneath_post_title() should contain view when the post type is 'tours'.
+	 */
+	public function test_should_contain_view_when_post_type_is_tours() {
+		Monkey\Functions\expect( 'get_post_type' )
+			->once()
+			->andReturn( 'tours' );
+		$expected_html = <<<VIEW
+<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
+VIEW;
+
+		// Fire the rendering function and grab the HTML out of the buffer.
+		ob_start();
+		add_description_beneath_post_title( $post );
 		$actual_html = ob_get_clean();
 
 		// Test the HTML.
-		$this->assertContains( '<span class="description">', $actual_html );
-		$this->assertContains( 'Enter the theme name above for this Cornerstone tour.', $actual_html );
-		$this->assertContains( 'In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour.', $actual_html );
+		$this->assertSame( $expected_html, $actual_html );
 	}
 }
+

--- a/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for add_description_beneath_post_title().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\CornerstoneTours\add_description_beneath_post_title;
+
+/**
+ * Class Tests_AddDescriptionBeneathPostTitle
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Unit
+ * @group   tours
+ * @group   admin
+ */
+class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once TOURS_ROOT_DIR . '/src/admin/edit-form-advanced.php';
+	}
+
+	/**
+	 * Test add_description_beneath_post_title() should return empty when the post type is not 'tours'.
+	 */
+	public function test_should_return_empty_when_post_type_is_not_tours() {
+		Functions\expect( 'get_post_type' )
+			->once()
+			->andReturn( 'post' );
+
+		$this->assertEmpty( add_description_beneath_post_title() );
+	}
+
+	/**
+	 * Test add_description_beneath_post_title() should return string when the post type is 'tours'.
+	 */
+	public function test_should_return_string_when_post_type_is_tours() {
+		Functions\expect( 'get_post_type' )
+			->once()
+			->andReturn( 'tours' );
+
+		// Fire the rendering function and grab the HTML out of the buffer.
+		ob_start();
+		add_description_beneath_post_title();
+		$actual_html = ob_get_clean();
+
+		// Test the HTML.
+		$this->assertContains( '<span class="description">', $actual_html );
+		$this->assertContains( 'Enter the theme name above for this Cornerstone tour.', $actual_html );
+		$this->assertContains( 'In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour.', $actual_html );
+	}
+}


### PR DESCRIPTION
## PR Summary 

This PR adds unit and integration tests for the function `add_description_beneath_post_title` in the `tours` plugin. The relative file path to the function is: 

>`tours/src/admin/edit-form-advanced.php`. 

The callback is registered to the following event in WordPress core: 

>`do_action( 'edit_form_before_permalink', $post );` 

located in: 

>`wp-admin/edit-form-advanced.php` L#526. 