### PR TITLE
PR#60 (setCustomColumns) | integration tests only

### DIFF
--- a/plugins/tours/src/admin/wp-list-table.php
+++ b/plugins/tours/src/admin/wp-list-table.php
@@ -15,11 +15,12 @@ add_filter( 'manage_tours_posts_columns', __NAMESPACE__ . '\set_custom_columns' 
 /**
  * Add custom columns to the Tours admin page.
  *
- * @return array Array of columns.
  * @since 1.0.0
+ * @param array[] $post_columns An associative array of column headings.
  *
+ * @return array An array of custom column headings.
  */
-function set_custom_columns() {
+function set_custom_columns( $post_columns ) {
 	return array(
 		'cb'         => '<input type="checkbox"/>',
 		'title'      => 'Tour Name',

--- a/plugins/tours/src/admin/wp-list-table.php
+++ b/plugins/tours/src/admin/wp-list-table.php
@@ -11,7 +11,7 @@
 
 namespace spiralWebDb\CornerstoneTours;
 
-add_filter( 'manage_tours_posts_columns', __NAMESPACE__ . '\set_custom_columns' );
+add_filter( 'manage_tours_posts_columns', __NAMESPACE__ . '\_set_custom_columns' );
 /**
  * Add custom columns to the Tours admin page.
  *
@@ -20,7 +20,7 @@ add_filter( 'manage_tours_posts_columns', __NAMESPACE__ . '\set_custom_columns' 
  *
  * @return array An array of custom column headings.
  */
-function set_custom_columns( $post_columns ) {
+function _set_custom_columns( $post_columns ) {
 	return array(
 		'cb'         => '<input type="checkbox"/>',
 		'title'      => 'Tour Name',

--- a/plugins/tours/src/admin/wp-list-table.php
+++ b/plugins/tours/src/admin/wp-list-table.php
@@ -16,11 +16,10 @@ add_filter( 'manage_tours_posts_columns', __NAMESPACE__ . '\_set_custom_columns'
  * Add custom columns to the Tours admin page.
  *
  * @since 1.0.0
- * @param array[] $post_columns An associative array of column headings.
  *
  * @return array An array of custom column headings.
  */
-function _set_custom_columns( $post_columns ) {
+function _set_custom_columns() {
 	return array(
 		'cb'         => '<input type="checkbox"/>',
 		'title'      => 'Tour Name',

--- a/plugins/tours/src/admin/wp-list-table.php
+++ b/plugins/tours/src/admin/wp-list-table.php
@@ -20,13 +20,13 @@ add_filter( 'manage_tours_posts_columns', __NAMESPACE__ . '\_set_custom_columns'
  * @return array An array of custom column headings.
  */
 function _set_custom_columns() {
-	return array(
+	return [
 		'cb'         => '<input type="checkbox"/>',
 		'title'      => 'Tour Name',
 		'tour_id'    => 'Tour ID',
 		'tour_year'  => 'Tour Year',
 		'menu_order' => 'Order Number',
-	);
+	];
 }
 
 add_action( 'manage_tours_posts_custom_column', __NAMESPACE__ . '\_render_custom_column_content', 10, 2 );

--- a/plugins/tours/tests/phpunit/integration/_setCustomColumns.php
+++ b/plugins/tours/tests/phpunit/integration/_setCustomColumns.php
@@ -21,7 +21,7 @@ use function spiralWebDb\CornerstoneTours\_set_custom_columns;
  * @group   tours
  * @group   admin
  */
-class Tests_SetCustomColumns extends Test_Case {
+class Tests__SetCustomColumns extends Test_Case {
 
 	/*
      * Test _set_custom_columns() should return expected array of custom admin columns.

--- a/plugins/tours/tests/phpunit/integration/setCustomColumns.php
+++ b/plugins/tours/tests/phpunit/integration/setCustomColumns.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for set_custom_columns().
+ * Tests for _set_custom_columns().
  *
  * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @since       1.0.0
@@ -12,7 +12,7 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function spiralWebDb\CornerstoneTours\set_custom_columns;
+use function spiralWebDb\CornerstoneTours\_set_custom_columns;
 
 /**
  * Class Tests_SetCustomColumns
@@ -24,34 +24,18 @@ use function spiralWebDb\CornerstoneTours\set_custom_columns;
 class Tests_SetCustomColumns extends Test_Case {
 
 	/*
-     * Test set_custom_columns() should return array of default admin columns for 'post' post type.
+     * Test _set_custom_columns() should return expected array of custom admin columns.
      */
-	public function test_should_return_array_of_default_post_admin_columns() {
-		$post_columns = [
-			'cb'    => '<input type="checkbox"/>',
-			'title' => _x( 'Title', 'column name' ),
-			'date'  => __( 'Date' ),
+	public function test_should_return_expected_array_of_custom_columns() {
+		 $expected = [
+			 'cb'         => '<input type="checkbox"/>',
+			 'title'      => 'Tour Name',
+			 'tour_id'    => 'Tour ID',
+			 'tour_year'  => 'Tour Year',
+			 'menu_order' => 'Order Number',
 		];
 
-		$this->assertTrue( is_array( set_custom_columns( $post_columns ) ) );
-		$this->assertArrayHasKey( 'cb', set_custom_columns( $post_columns ) );
-		$this->assertArrayHasKey( 'title', set_custom_columns( $post_columns ) );
-	}
-
-	/*
-	 * Test set_custom_columns() should return filtered array of additional admin columns for 'tours' post type.
-	 */
-	public function test_should_return_filtered_array_of_additional_tours_admin_columns() {
-		$post_columns = [
-			'cb'    => '<input type="checkbox"/>',
-			'title' => _x( 'Title', 'column name' ),
-			'date'  => __( 'Date' ),
-		];
-
-		$this->assertTrue( is_array( set_custom_columns( $post_columns ) ) );
-		$this->assertArrayHasKey( 'tour_id', set_custom_columns( $post_columns ) );
-		$this->assertArrayHasKey( 'tour_year', set_custom_columns( $post_columns ) );
-		$this->assertArrayHasKey( 'menu_order', set_custom_columns( $post_columns ) );
+		$this->assertSame( $expected, _set_custom_columns() );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/setCustomColumns.php
+++ b/plugins/tours/tests/phpunit/integration/setCustomColumns.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests for set_custom_columns().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function spiralWebDb\CornerstoneTours\set_custom_columns;
+
+/**
+ * Class Tests_SetCustomColumns
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ * @group   admin
+ */
+class Tests_SetCustomColumns extends Test_Case {
+	
+	/*
+    * Test set_custom_columns() should return array of default admin columns for 'post' post type.
+    */
+	public function test_should_return_array_of_default_post_admin_columns() {
+		$post_columns = [
+			'cb'    => '<input type="checkbox"/>',
+			'title' => _x( 'Title', 'column name' ),
+			'date'  => __( 'Date' ),
+		];
+
+		$this->assertTrue( is_array( set_custom_columns( $post_columns ) ) );
+		$this->assertArrayHasKey( 'cb', set_custom_columns( $post_columns ) );
+		$this->assertArrayHasKey( 'title', set_custom_columns( $post_columns ) );
+	}
+
+	/*
+	 * Test set_custom_columns() should return array of additional admin columns for 'tours' post type.
+	 */
+	public function test_should_return_array_of_additional_tours_admin_columns() {
+		$post_columns = [
+			'cb'    => '<input type="checkbox"/>',
+			'title' => _x( 'Title', 'column name' ),
+			'date'  => __( 'Date' ),
+		];
+
+		$this->assertTrue( is_array( set_custom_columns( $post_columns ) ) );
+		$this->assertArrayHasKey( 'tour_id', set_custom_columns( $post_columns ) );
+		$this->assertArrayHasKey( 'tour_year', set_custom_columns( $post_columns ) );
+		$this->assertArrayHasKey( 'menu_order', set_custom_columns( $post_columns ) );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/integration/setCustomColumns.php
+++ b/plugins/tours/tests/phpunit/integration/setCustomColumns.php
@@ -22,10 +22,10 @@ use function spiralWebDb\CornerstoneTours\set_custom_columns;
  * @group   admin
  */
 class Tests_SetCustomColumns extends Test_Case {
-	
+
 	/*
-    * Test set_custom_columns() should return array of default admin columns for 'post' post type.
-    */
+     * Test set_custom_columns() should return array of default admin columns for 'post' post type.
+     */
 	public function test_should_return_array_of_default_post_admin_columns() {
 		$post_columns = [
 			'cb'    => '<input type="checkbox"/>',
@@ -39,9 +39,9 @@ class Tests_SetCustomColumns extends Test_Case {
 	}
 
 	/*
-	 * Test set_custom_columns() should return array of additional admin columns for 'tours' post type.
+	 * Test set_custom_columns() should return filtered array of additional admin columns for 'tours' post type.
 	 */
-	public function test_should_return_array_of_additional_tours_admin_columns() {
+	public function test_should_return_filtered_array_of_additional_tours_admin_columns() {
 		$post_columns = [
 			'cb'    => '<input type="checkbox"/>',
 			'title' => _x( 'Title', 'column name' ),


### PR DESCRIPTION
## PR Summary

This PR adds integration tests for the function `_set_column_classes( $post_classes )` registered to the WordPress filter `'manage_tours_posts_columns'`.  The function is used in the `tours` plugin to register custom column classes in the plugin admin. The relative file path to the function within the plugin is: 

>`/tours/src/admin/wp-list-table.php`.

The function `set_column_classes` simply returns an array to the filter. There are no unit tests for this function.  