### PR TITLE
PR#61 (_setSortableColumns) | integration tests only

### DIFF
--- a/plugins/tours/src/admin/wp-list-table.php
+++ b/plugins/tours/src/admin/wp-list-table.php
@@ -58,14 +58,15 @@ add_filter( 'manage_edit-tours_sortable_columns', __NAMESPACE__ . '\_set_sortabl
 /**
  * Set sortable columns on the Tours admin page.
  *
- * @return array New sortable columns.
+ * @param array $sortable_columns An array of sortable columns.
+ * @return array  New sortable columns.
  * @since 1.0.0
  *
  */
-function _set_sortable_columns() {
-	return array(
+function _set_sortable_columns( $sortable_columns ) {
+	return [
 		'tour_id'    => 'Tour ID',
 		'tour_year'  => 'Tour Year',
 		'menu_order' => 'Order Number',
-	);
+	];
 }

--- a/plugins/tours/src/admin/wp-list-table.php
+++ b/plugins/tours/src/admin/wp-list-table.php
@@ -60,10 +60,9 @@ add_filter( 'manage_edit-tours_sortable_columns', __NAMESPACE__ . '\_set_sortabl
  *
  * @since 1.0.0
  *
- * @param array $sortable_columns An array of sortable columns.
- * @return array  New sortable columns.
+ * @return array  Array of new sortable columns.
  */
-function _set_sortable_columns( $sortable_columns ) {
+function _set_sortable_columns() {
 	return [
 		'tour_id'    => 'Tour ID',
 		'tour_year'  => 'Tour Year',

--- a/plugins/tours/src/admin/wp-list-table.php
+++ b/plugins/tours/src/admin/wp-list-table.php
@@ -58,10 +58,10 @@ add_filter( 'manage_edit-tours_sortable_columns', __NAMESPACE__ . '\_set_sortabl
 /**
  * Set sortable columns on the Tours admin page.
  *
- * @param array $sortable_columns An array of sortable columns.
- * @return array  New sortable columns.
  * @since 1.0.0
  *
+ * @param array $sortable_columns An array of sortable columns.
+ * @return array  New sortable columns.
  */
 function _set_sortable_columns( $sortable_columns ) {
 	return [

--- a/plugins/tours/tests/phpunit/integration/_setSortableColumns.php
+++ b/plugins/tours/tests/phpunit/integration/_setSortableColumns.php
@@ -22,48 +22,18 @@ use function spiralWebDb\CornerstoneTours\_set_sortable_columns;
  * @group   admin
  */
 class Tests__SetSortableColumns extends Test_Case {
-	/**
-	 * Test _set_sortable_columns() should return an array when registered to filter.
-	 */
-	public function test_should_return_an_array_when_registered_to_filter() {
-		$sortable_columns = [
-			'title'    => 'title',
-			'parent'   => 'parent',
-			'comments' => 'comment_count',
-			'date'     => [ 'date', true ],
-		];
-
-		$this->assertContains( is_array( $sortable_columns ), _set_sortable_columns( $sortable_columns ) );
-		$this->assertArrayHasKey( 'title', $sortable_columns );
-		$this->assertArrayHasKey( 'parent', $sortable_columns );
-		$this->assertArrayHasKey( 'comments', $sortable_columns );
-		$this->assertArrayHasKey( 'date', $sortable_columns );
-	}
 
 	/**
-	 * Test _set_sortable_columns() should return a filtered array when registered to filter.
+	 * Test _set_sortable_columns() should return filtered array of sortable columns.
 	 */
-	public function test_should_return_filtered_array_when_registered_to_filter() {
-		$sortable_columns = [
-			'title'    => 'title',
-			'parent'   => 'parent',
-			'comments' => 'comment_count',
-			'date'     => [ 'date', true ],
-		];
-
+	public function test_should_return_filtered_array_of_sortable_columns() {
 		$expected = [
 			'tour_id'    => 'Tour ID',
 			'tour_year'  => 'Tour Year',
 			'menu_order' => 'Order Number',
 		];
 
-		$this->assertSame( $expected, _set_sortable_columns( $sortable_columns ) );
-		$this->assertArrayHasKey( 'tour_id', _set_sortable_columns( $sortable_columns ) );
-		$this->assertArrayHasKey( 'tour_year', _set_sortable_columns( $sortable_columns ) );
-		$this->assertArrayHasKey( 'menu_order', _set_sortable_columns( $sortable_columns ) );
-
-
-
+		$this->assertSame( $expected, _set_sortable_columns() );
 	}
-
 }
+

--- a/plugins/tours/tests/phpunit/integration/_setSortableColumns.php
+++ b/plugins/tours/tests/phpunit/integration/_setSortableColumns.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests for _set_sortable_columns().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function spiralWebDb\CornerstoneTours\_set_sortable_columns;
+
+/**
+ * Class Tests__SetSortableColumns
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ * @group   admin
+ */
+class Tests__SetSortableColumns extends Test_Case {
+	/**
+	 * Test _set_sortable_columns() should return an array when registered to filter.
+	 */
+	public function test_should_return_an_array_when_registered_to_filter() {
+		$sortable_columns = [
+			'title'    => 'title',
+			'parent'   => 'parent',
+			'comments' => 'comment_count',
+			'date'     => [ 'date', true ],
+		];
+
+		$this->assertContains( is_array( $sortable_columns ), _set_sortable_columns( $sortable_columns ) );
+		$this->assertArrayHasKey( 'title', $sortable_columns );
+		$this->assertArrayHasKey( 'parent', $sortable_columns );
+		$this->assertArrayHasKey( 'comments', $sortable_columns );
+		$this->assertArrayHasKey( 'date', $sortable_columns );
+	}
+
+	/**
+	 * Test _set_sortable_columns() should return a filtered array when registered to filter.
+	 */
+	public function test_should_return_filtered_array_when_registered_to_filter() {
+		$sortable_columns = [
+			'title'    => 'title',
+			'parent'   => 'parent',
+			'comments' => 'comment_count',
+			'date'     => [ 'date', true ],
+		];
+
+		$expected = [
+			'tour_id'    => 'Tour ID',
+			'tour_year'  => 'Tour Year',
+			'menu_order' => 'Order Number',
+		];
+
+		$this->assertSame( $expected, _set_sortable_columns( $sortable_columns ) );
+		$this->assertArrayHasKey( 'tour_id', _set_sortable_columns( $sortable_columns ) );
+		$this->assertArrayHasKey( 'tour_year', _set_sortable_columns( $sortable_columns ) );
+		$this->assertArrayHasKey( 'menu_order', _set_sortable_columns( $sortable_columns ) );
+
+
+
+	}
+
+}


### PR DESCRIPTION
## PR Summary

This PR adds 2 integration tests for the function `_set_sortable_columns( $sortable_columns )`. registered to the filter `'manage_edit-tours_sortable_columns'`. The relative file path to the function (from within the `tours` plugin ) is: 

>`/tours/src/admin/wp-list-table.php`. 

There are no unit tests for this function, as it returns the filtered value of the `$sortable_columns` array passed by the filter. 