### PR TITLE
PR#62 (_renderCustomColumnContent)

### DIFF
--- a/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for _render_custom_column_content().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
+
+/**
+ * Class Tests__RenderCustomColumnContent
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ * @group   admin
+ */
+class Tests__RenderCustomColumnContent extends Test_Case {
+
+	/*
+	 * Test _render_custom_column_content() should echo $tour_id when column_name is 'tour_id'.
+	 */
+	public function test_should_echo_tour_id_when_column_name_is_tour_id() {
+		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
+		$post        = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
+		$column_name = 'tour_id';
+
+		ob_start();
+		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
+		$actual = (int) ob_get_clean();
+
+		$this->assertSame( $post->ID, $actual );
+	}
+
+	/*
+	 * Test _render_custom_column_content() should echo $tour_year when column_name is 'tour_year'.
+	 */
+	public function test_should_echo_tour_year_when_column_name_is_tour_year() {
+		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
+		$post = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
+
+		// Add post_meta to the database so we can call it.
+		add_post_meta( $post->ID, 'tour_year', '2018' );
+
+		$column_name = 'tour_year';
+		$expected    = (int) get_post_meta( $post->ID, 'tour_year', true );
+
+		ob_start();
+		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
+		$actual = (int) ob_get_clean();
+
+		$this->assertSame( $expected, $actual );
+
+		// Clean up database.
+		delete_post_meta( $post->ID, 'tour_year' );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
@@ -12,7 +12,6 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
 
 /**
  * Class Tests__RenderCustomColumnContent

--- a/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
@@ -29,13 +29,14 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
 		$post        = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
 		$column_name = 'tour_id';
+		$expected    = $post->ID;
 
 		// Run the output buffer to fire the event to which the callback is registered.
 		ob_start();
 		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
 		$actual = (int) ob_get_clean();
 
-		$this->assertSame( $post->ID, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 
 	/*

--- a/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
@@ -62,5 +62,27 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 		// Clean up database.
 		delete_post_meta( $post->ID, 'tour_year' );
 	}
+
+	/*
+	 * Test _render_custom_column_content() should echo $menu_order when column_name is 'menu_order'.
+	 */
+	public function test_should_echo_menu_order_when_column_name_is_menu_order() {
+		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
+		$post        = self::factory()->post->create_and_get(
+			[
+				'post_type'  => 'tours',
+				'menu_order' => 5
+			]
+		);
+		$column_name = 'menu_order';
+		$expected    = $post->menu_order;
+
+		// Run the output buffer to fire the event to which the callback is registered.
+		ob_start();
+		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
+		$actual = (int) ob_get_clean();
+
+		$this->assertSame( $expected, $actual );
+	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/integration/_renderCustomColumnContent.php
@@ -31,6 +31,7 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 		$post        = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
 		$column_name = 'tour_id';
 
+		// Run the output buffer to fire the event to which the callback is registered.
 		ob_start();
 		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
 		$actual = (int) ob_get_clean();
@@ -51,6 +52,7 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 		$column_name = 'tour_year';
 		$expected    = (int) get_post_meta( $post->ID, 'tour_year', true );
 
+		// Run the output buffer to fire the event to which the callback is registered.
 		ob_start();
 		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
 		$actual = (int) ob_get_clean();

--- a/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
@@ -24,28 +24,7 @@ use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
  * @group   admin
  */
 class Tests_RenderCustomColumnContent extends Test_Case {
-
-	/**
-	 * Instance of the post object for each test.
-	 *
-	 * @var Mockery
-	 */
-	protected $post;
-
-	/**
-	 * The post ID
-	 *
-	 * @var integer
-	 */
-	protected $ID;
-
-	/**
-	 * The post type
-	 *
-	 * @var string
-	 */
-	protected $post_type;
-
+	
 	/**
 	 * Prepares the test environment before each test.
 	 */

--- a/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
@@ -22,28 +22,74 @@ use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
  * @group   tours
  * @group   admin
  */
-class Tests_RenderCustomColumnContent extends Test_Case {
+class Tests__RenderCustomColumnContent extends Test_Case {
 
 	/**
 	 * Prepares the test environment before each test.
 	 */
-	protected function setUpBeforeClass() {
-		parent::setUp();
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 
 		require_once TOURS_ROOT_DIR . '/src/admin/wp-list-table.php';
 	}
 
 	/**
-	 *  Test _render_custom_column_content() should echo 'tour_id' when evaluating $column_name.
+	 *  Test _render_custom_column_content() should echo 'tour_id' when $tour_id is given.
 	 */
-	public function test_should_echo_tour_id_when_evaluating_column_name() {
-		Monkey\Functions\expect( '_render_custom_column_content' )
-			->once()
-			->with( 'column_name', 'tour_id' )
-			->andReturn( 99 );
-		$expected = $this->post->ID;
+	public function test_should_echo_tour_id_when_column_name_is_tour_id() {
+		$tour_id = 99;
 
-		$this->assertSame( $expected, _render_custom_column_content( $column_name, $this->post->ID ) );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $tour_id, 'tour_year', true )
+			->never();
+		Monkey\Functions\expect( 'get_post_field' )
+			->once()
+			->with( 'menu_order', $tour_id )
+			->never();
+
+		$this->expectOutputString( $tour_id );
+		_render_custom_column_content( 'tour_id', $tour_id );
+	}
+
+	/*
+	 * Test _render_custom_column_content() should echo the 'tour_year' when $tour_year is given.
+	 */
+	public function test_should_echo_tour_year_when_tour_year_is_given() {
+		$tour_id   = 157;
+		$tour_year = 2018;
+
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $tour_id, 'tour_year', true )
+			->andReturn( $tour_year );
+		Monkey\Functions\expect( 'get_post_field' )
+			->once()
+			->with( 'menu_order', $tour_id )
+			->never();
+
+		$this->expectOutputString( $tour_year );
+		_render_custom_column_content( 'tour_year', $tour_id );
+	}
+
+	/*
+	 * Test _render_custom_column_content() should echo the 'menu_order' when $menu_order is given.
+	 */
+	public function test_should_echo_menu_order_when_menu_order_is_given() {
+		$tour_id    = 211;
+		$menu_order = 5;
+
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $tour_id, 'tour_year', true )
+			->never();
+		Monkey\Functions\expect( 'get_post_field' )
+			->once()
+			->with( 'menu_order', $tour_id )
+			->andReturn( $menu_order );
+
+		$this->expectOutputString( $menu_order );
+		_render_custom_column_content( 'menu_order', $tour_id );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
@@ -11,7 +11,6 @@
 
 namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
-use Mockery as m;
 use Brain\Monkey;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
@@ -24,18 +23,14 @@ use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
  * @group   admin
  */
 class Tests_RenderCustomColumnContent extends Test_Case {
-	
+
 	/**
 	 * Prepares the test environment before each test.
 	 */
-	protected function setUp() {
+	protected function setUpBeforeClass() {
 		parent::setUp();
 
 		require_once TOURS_ROOT_DIR . '/src/admin/wp-list-table.php';
-
-		$this->post = m::mock( 'post' );
-		$this->post->ID = (int) 99;
-		$this->post->post_type = 'tours';
 	}
 
 	/**

--- a/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
@@ -16,7 +16,7 @@ use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
 
 /**
- * Class Tests_RenderCustomColumnContent
+ * Class Tests__RenderCustomColumnContent
  *
  * @package spiralWebDb\CornerstoneTours\Tests\Unit
  * @group   tours

--- a/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
@@ -69,7 +69,7 @@ class Tests_RenderCustomColumnContent extends Test_Case {
 			->andReturn( 99 );
 		$expected = $this->post->ID;
 
-		$this->assertNotNull( _render_custom_column_content( $column_name, $this->post->ID ) );
+		$this->assertSame( $expected, _render_custom_column_content( $column_name, $this->post->ID ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/_renderCustomColumnContent.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Tests for _render_custom_column_content().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Unit;
+
+use Mockery as m;
+use Brain\Monkey;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
+
+/**
+ * Class Tests_RenderCustomColumnContent
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Unit
+ * @group   tours
+ * @group   admin
+ */
+class Tests_RenderCustomColumnContent extends Test_Case {
+
+	/**
+	 * Instance of the post object for each test.
+	 *
+	 * @var Mockery
+	 */
+	protected $post;
+
+	/**
+	 * The post ID
+	 *
+	 * @var integer
+	 */
+	protected $ID;
+
+	/**
+	 * The post type
+	 *
+	 * @var string
+	 */
+	protected $post_type;
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once TOURS_ROOT_DIR . '/src/admin/wp-list-table.php';
+
+		$this->post = m::mock( 'post' );
+		$this->post->ID = (int) 99;
+		$this->post->post_type = 'tours';
+	}
+
+	/**
+	 *  Test _render_custom_column_content() should echo 'tour_id' when evaluating $column_name.
+	 */
+	public function test_should_echo_tour_id_when_evaluating_column_name() {
+		Monkey\Functions\expect( '_render_custom_column_content' )
+			->once()
+			->with( 'column_name', 'tour_id' )
+			->andReturn( 99 );
+		$expected = $this->post->ID;
+
+		$this->assertNotNull( _render_custom_column_content( $column_name, $this->post->ID ) );
+	}
+}
+


### PR DESCRIPTION
## PR Summary

This PR contains the unit and integration tests for the function `_render_custom_column_content` in the `tours` plugin.  The function under test includes 3 `switch` statements, each of which echoes an integer value to the browser on the plugin admin page. 

The relative path to the plugin file that contains the function under test is: 

>`wp-content/plugins/tours/src/admin/wp-list-table.php`.

The function is registered to the event: 

>`do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );`

in the WordPress core file: 

>`wp-admin/includes/class-wp-posts-list-table.php` L#1265. 

Each of the 3 integration tests use PHP's output buffer to fire the event `"manage_{$post->post_type}_posts_custom_column"`  and return the value of the callback  `_render_custom_column_content` registered to that event.  The callback's return value is dependent on which `$column_name` is invoked. 