### PR TITLE
PR #65 (renderTheTourRegions | add @dataProvider method)

### DIFF
--- a/plugins/tours/tests/phpunit/integration/renderTheTourRegions.php
+++ b/plugins/tours/tests/phpunit/integration/renderTheTourRegions.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Tests for render_the_tour_regions().
+ *
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function spiralWebDb\CornerstoneTours\render_the_tour_regions;
+
+/**
+ * @covers ::\spiralWebDb\CornerstoneTours\render_the_tour_regions
+ *
+ * @group   tours
+ */
+class Tests_RenderTheTourRegions extends Test_Case {
+
+	/**
+	 * @dataProvider addTestData
+	 */
+	public function test_should_echo_meta_key_values_when_postmeta_exists( $post_data, $meta ) {
+		// Create and get the $tour_id using WordPress' factory method.
+		$tour_id = $this->factory->post->create( $post_data );
+
+		// Add post_meta to the database so we can call it.
+		add_post_meta( $tour_id, 'tour_region', $meta['tour_region'] );
+
+		$expected = (string) get_post_meta( $tour_id, 'tour_region', true );
+
+		// Run the output buffer to fire the callback and return the output.
+		ob_start();
+		render_the_tour_regions( $tour_id );
+		$actual = ob_get_clean();
+
+		$this->assertSame( $expected, $actual );
+
+		// Clean up database.
+		delete_post_meta( $tour_id, 'tour_region' );
+	}
+
+	public function addTestData() {
+		return [
+			'postmeta key value is empty'     => [
+				'post_data' => [
+					'post_type' => 'tours'
+				],
+				'post_meta' => [
+					'tour_region' => ''
+				]
+			],
+			'postmeta key value1 exists' => [
+				'post_data' => [
+					'post_type' => 'tours'
+				],
+				'post_meta' => [
+					'tour_region' => 'Midwest/West/Southwest'
+				]
+			],
+			'postmeta key value2 exists' => [
+				'post_data' => [
+					'post_type' => 'tours'
+				],
+				'post_meta' => [
+					'tour_region' => 'Midwest/Mid-Atlantic/Southeast'
+				]
+			]
+		];
+	}
+}
+

--- a/plugins/tours/tests/phpunit/integration/renderTheTourRegions.php
+++ b/plugins/tours/tests/phpunit/integration/renderTheTourRegions.php
@@ -22,31 +22,43 @@ use function spiralWebDb\CornerstoneTours\render_the_tour_regions;
 class Tests_RenderTheTourRegions extends Test_Case {
 
 	/**
+	 * Cleans up the test environment after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		// Clean up database.
+		delete_post_meta( $this->tour_id, $this->meta );
+	}
+
+	/**
 	 * @dataProvider addTestData
 	 */
 	public function test_should_echo_meta_key_values_when_postmeta_exists( $post_data, $meta ) {
-		// Create and get the $tour_id using WordPress' factory method.
-		$tour_id = $this->factory->post->create( $post_data );
+		// Get the $tour_id using WordPress' factory method.
+		$this->tour_id = $this->factory->post->create( $post_data );
+		// Assign the $meta parameter to a property of the test class.
+		$this->meta = $meta;
 
 		// Add post_meta to the database so we can call it.
-		add_post_meta( $tour_id, 'tour_region', $meta['tour_region'] );
+		foreach ( $meta as $key => $value ) {
+			add_post_meta( $this->tour_id, $key, $value );
+		}
 
-		$expected = (string) get_post_meta( $tour_id, 'tour_region', true );
+		$region   = (string) get_post_meta( $this->tour_id, 'tour_region', true );
+		$expected = esc_html( $region );
 
 		// Run the output buffer to fire the callback and return the output.
 		ob_start();
-		render_the_tour_regions( $tour_id );
+		render_the_tour_regions( $this->tour_id );
 		$actual = ob_get_clean();
 
 		$this->assertSame( $expected, $actual );
-
-		// Clean up database.
-		delete_post_meta( $tour_id, 'tour_region' );
 	}
 
 	public function addTestData() {
 		return [
-			'postmeta key value is empty'     => [
+			'postmeta key value is empty' => [
 				'post_data' => [
 					'post_type' => 'tours'
 				],
@@ -54,7 +66,7 @@ class Tests_RenderTheTourRegions extends Test_Case {
 					'tour_region' => ''
 				]
 			],
-			'postmeta key value1 exists' => [
+			'postmeta key value1 exists'  => [
 				'post_data' => [
 					'post_type' => 'tours'
 				],
@@ -62,7 +74,7 @@ class Tests_RenderTheTourRegions extends Test_Case {
 					'tour_region' => 'Midwest/West/Southwest'
 				]
 			],
-			'postmeta key value2 exists' => [
+			'postmeta key value2 exists'  => [
 				'post_data' => [
 					'post_type' => 'tours'
 				],

--- a/plugins/tours/tests/phpunit/unit/renderTheTourRegions.php
+++ b/plugins/tours/tests/phpunit/unit/renderTheTourRegions.php
@@ -34,13 +34,16 @@ class Tests_RenderTheTourRegions extends Test_Case {
 	/**
 	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $postmeta ) {
+	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $meta, $expected ) {
 		Functions\expect( 'get_post_meta' )
-			->once()
+			->times( 1 )
 			->with( $tour_id, 'tour_region', true )
-			->andReturn( $postmeta );
+			->andReturn( $meta );
 
-		$this->expectOutputString( $tour_id );
+		if ( ! is_null( $expected ) ) {
+			$this->expectOutputString( $expected );
+		}
+
 		render_the_tour_regions( $tour_id );
 	}
 
@@ -49,14 +52,17 @@ class Tests_RenderTheTourRegions extends Test_Case {
 			'postmeta key value is empty' => [
 				'tour_id'     => 79,
 				'tour_region' => '',
+				'expected'    => '',
 			],
 			'postmeta key value1 exists'  => [
 				'tour_id'     => 106,
 				'tour_region' => 'Midwest/Mid-Atlantic/Southeast',
+				'expected'    => 'Midwest/Mid-Atlantic/Southeast',
 			],
 			'postmeta key value2 exists'  => [
 				'tour_id'     => 147,
 				'tour_region' => 'Midwest/West Coast/Southwest',
+				'expected'    => 'Midwest/West Coast/Southwest',
 			],
 		];
 	}

--- a/plugins/tours/tests/phpunit/unit/renderTheTourRegions.php
+++ b/plugins/tours/tests/phpunit/unit/renderTheTourRegions.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for render_the_tour_regions().
+ *
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\CornerstoneTours\render_the_tour_regions;
+
+/**
+ * @covers ::\spiralWebDb\CornerstoneTours\render_the_tour_regions
+ *
+ * @group   tours
+ */
+class Tests_RenderTheTourRegions extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once TOURS_ROOT_DIR . '/src/meta.php';
+	}
+
+	/**
+	 * @dataProvider addTestData
+	 */
+	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $postmeta ) {
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $tour_id, 'tour_region', true )
+			->andReturn( $postmeta );
+
+		$this->expectOutputString( $tour_id );
+		render_the_tour_regions( $tour_id );
+	}
+
+	public function addTestData() {
+		return [
+			'postmeta key value is empty' => [
+				'tour_id'     => 79,
+				'tour_region' => '',
+			],
+			'postmeta key value1 exists'  => [
+				'tour_id'     => 106,
+				'tour_region' => 'Midwest/Mid-Atlantic/Southeast',
+			],
+			'postmeta key value2 exists'  => [
+				'tour_id'     => 147,
+				'tour_region' => 'Midwest/West Coast/Southwest',
+			],
+		];
+	}
+}
+


### PR DESCRIPTION
## PR Summary

This PR includes one unit and integration test each for the function `render_the_tour_regions` in the `tours` plugin. The function gets and echos the post meta `tour_region` into the HTML view displayed in the title of each past tour.  The unit and integration tests each employ a `@dataProvider` method to pass test data to their respective test methods. 

The relative file path from within the plugin to the function under test is: 

>`/tours/src/meta.php`.