### PR TITLE
PR#66 (renderTourComments | add @dataProvider method)

### DIFF
--- a/plugins/tours/tests/phpunit/integration/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/integration/renderTourComments.php
@@ -22,32 +22,41 @@ use function spiralWebDb\CornerstoneTours\render_tour_comments;
 class Tests_RenderTourComments extends Test_Case {
 
 	/**
+	 * Cleans up the test environment after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		// Clean up database.
+		delete_post_meta( $this->tour_id, 'tour_comments' );
+	}
+
+	/**
 	 * @dataProvider addTestData
 	 */
 	public function test_should_echo_meta_key_values_when_postmeta_exists( $post_data, $meta ) {
-		// Create and get the $tour_id using WordPress' factory method.
-		$tour_id = $this->factory->post->create( $post_data );
+		// Get the $tour_id using WordPress' factory method.
+		$this->tour_id = $this->factory->post->create( $post_data );
 
 		// Add post_meta to the database so we can call it.
-		add_post_meta( $tour_id, 'tour_comments', $meta['tour_comments']
-		);
+		foreach ( $meta as $key => $value ) {
+			add_post_meta( $this->tour_id, $key, $value );
+		}
 
-		$expected = (string) get_post_meta( $tour_id, 'tour_comments', true );
-
+		$comments = (string) get_post_meta( $this->tour_id, 'tour_comments', true );
+		$expected = esc_html( $comments );
+		
 		// Run the output buffer to fire the callback and return the output.
 		ob_start();
-		render_tour_comments( $tour_id );
+		render_tour_comments( $this->tour_id );
 		$actual = ob_get_clean();
 
 		$this->assertSame( $expected, $actual );
-
-		// Clean up database.
-		delete_post_meta( $tour_id, 'tour_comments' );
 	}
 
 	public function addTestData() {
 		return [
-			'empty postmeta key value'  => [
+			'empty postmeta key value'   => [
 				'post_data' => [
 					'post_type' => 'tours'
 				],

--- a/plugins/tours/tests/phpunit/integration/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/integration/renderTourComments.php
@@ -2,9 +2,9 @@
 /**
  * Tests for render_tour_comments().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
@@ -12,25 +12,21 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function add_post_meta;
-use function get_post_meta;
-use function delete_post_meta;
 use function spiralWebDb\CornerstoneTours\render_tour_comments;
 
 /**
- * Class Tests_RenderTourComments
+ * @covers ::\spiralWebDb\CornerstoneTours\render_tour_comments
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Integration
  * @group   tours
  */
 class Tests_RenderTourComments extends Test_Case {
 
-	/*
-	 * Test render_the_tour_regions() should echo 'tour_comments' when post_meta is available.
+	/**
+	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_tour_comments_when_post_meta_is_available_from_database() {
+	public function test_should_echo_tour_comments_when_post_meta_is_available_from_database( $post_data ) {
 		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
-		$post    = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
+		$post = $this->factory->post->create_and_get( $post_data );
 
 		// Add post_meta to the database so we can call it.
 		add_post_meta(
@@ -39,7 +35,7 @@ class Tests_RenderTourComments extends Test_Case {
 			'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY'
 		);
 
-		$expected    = (string) get_post_meta( $post->ID, 'tour_comments', true );
+		$expected = (string) get_post_meta( $post->ID, 'tour_comments', true );
 
 		// Run the output buffer to fire the callback and return the output.
 		ob_start();
@@ -60,7 +56,7 @@ class Tests_RenderTourComments extends Test_Case {
 			'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY'
 		);
 
-		$expected    = (string) get_post_meta( $post->ID, 'tour_comments', true );
+		$expected = (string) get_post_meta( $post->ID, 'tour_comments', true );
 
 		// Run the output buffer to fire the callback and return the output.
 		ob_start();
@@ -71,6 +67,16 @@ class Tests_RenderTourComments extends Test_Case {
 
 		// Clean up database.
 		delete_post_meta( $post->ID, 'tour_region' );
+	}
+
+	public function addTestData() {
+		return [
+			'init_post_data' => [
+				'post_data' => [
+					'post_type' => 'tours'
+				]
+			]
+		];
 	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/integration/renderTourComments.php
@@ -24,56 +24,51 @@ class Tests_RenderTourComments extends Test_Case {
 	/**
 	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_tour_comments_when_post_meta_is_available_from_database( $post_data ) {
-		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
-		$post = $this->factory->post->create_and_get( $post_data );
+	public function test_should_echo_meta_key_values_when_postmeta_exists( $post_data, $meta ) {
+		// Create and get the $tour_id using WordPress' factory method.
+		$tour_id = $this->factory->post->create( $post_data );
 
 		// Add post_meta to the database so we can call it.
-		add_post_meta(
-			$post->ID,
-			'tour_comments',
-			'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY'
+		add_post_meta( $tour_id, 'tour_comments', $meta['tour_comments']
 		);
 
-		$expected = (string) get_post_meta( $post->ID, 'tour_comments', true );
+		$expected = (string) get_post_meta( $tour_id, 'tour_comments', true );
 
 		// Run the output buffer to fire the callback and return the output.
 		ob_start();
-		render_tour_comments( $post->ID );
+		render_tour_comments( $tour_id );
 		$actual = ob_get_clean();
 
 		$this->assertSame( $expected, $actual );
 
 		// Clean up database.
-		delete_post_meta( $post->ID, 'tour_region' );
-
-		// Let's add some different post_meta and test the callback again.
-
-		// Add post_meta to the database so we can call it.
-		add_post_meta(
-			$post->ID,
-			'tour_comments',
-			'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY'
-		);
-
-		$expected = (string) get_post_meta( $post->ID, 'tour_comments', true );
-
-		// Run the output buffer to fire the callback and return the output.
-		ob_start();
-		render_tour_comments( $post->ID );
-		$actual = ob_get_clean();
-
-		$this->assertSame( $expected, $actual );
-
-		// Clean up database.
-		delete_post_meta( $post->ID, 'tour_region' );
+		delete_post_meta( $tour_id, 'tour_comments' );
 	}
 
 	public function addTestData() {
 		return [
-			'init_post_data' => [
+			'empty postmeta key value'  => [
 				'post_data' => [
 					'post_type' => 'tours'
+				],
+				'post_meta' => [
+					'tour_comments' => ''
+				]
+			],
+			'postmeta key value1 exists' => [
+				'post_data' => [
+					'post_type' => 'tours'
+				],
+				'post_meta' => [
+					'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY'
+				]
+			],
+			'postmeta key value2 exists' => [
+				'post_data' => [
+					'post_type' => 'tours'
+				],
+				'post_meta' => [
+					'tour_comments' => 'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY'
 				]
 			]
 		];

--- a/plugins/tours/tests/phpunit/integration/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/integration/renderTourComments.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Tests for render_tour_comments().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function add_post_meta;
+use function get_post_meta;
+use function delete_post_meta;
+use function spiralWebDb\CornerstoneTours\render_tour_comments;
+
+/**
+ * Class Tests_RenderTourComments
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ */
+class Tests_RenderTourComments extends Test_Case {
+
+	/*
+	 * Test render_the_tour_regions() should echo 'tour_comments' when post_meta is available.
+	 */
+	public function test_should_echo_tour_comments_when_post_meta_is_available_from_database() {
+		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
+		$post    = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
+
+		// Add post_meta to the database so we can call it.
+		add_post_meta(
+			$post->ID,
+			'tour_comments',
+			'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY'
+		);
+
+		$expected    = (string) get_post_meta( $post->ID, 'tour_comments', true );
+
+		// Run the output buffer to fire the callback and return the output.
+		ob_start();
+		render_tour_comments( $post->ID );
+		$actual = ob_get_clean();
+
+		$this->assertSame( $expected, $actual );
+
+		// Clean up database.
+		delete_post_meta( $post->ID, 'tour_region' );
+
+		// Let's add some different post_meta and test the callback again.
+
+		// Add post_meta to the database so we can call it.
+		add_post_meta(
+			$post->ID,
+			'tour_comments',
+			'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY'
+		);
+
+		$expected    = (string) get_post_meta( $post->ID, 'tour_comments', true );
+
+		// Run the output buffer to fire the callback and return the output.
+		ob_start();
+		render_tour_comments( $post->ID );
+		$actual = ob_get_clean();
+
+		$this->assertSame( $expected, $actual );
+
+		// Clean up database.
+		delete_post_meta( $post->ID, 'tour_region' );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/integration/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/integration/renderTourComments.php
@@ -28,7 +28,7 @@ class Tests_RenderTourComments extends Test_Case {
 		parent::tearDown();
 
 		// Clean up database.
-		delete_post_meta( $this->tour_id, 'tour_comments' );
+		delete_post_meta( $this->tour_id, $this->meta );
 	}
 
 	/**
@@ -37,6 +37,8 @@ class Tests_RenderTourComments extends Test_Case {
 	public function test_should_echo_meta_key_values_when_postmeta_exists( $post_data, $meta ) {
 		// Get the $tour_id using WordPress' factory method.
 		$this->tour_id = $this->factory->post->create( $post_data );
+		// Assign the $meta parameter to a property of the test class.
+		$this->meta = $meta;
 
 		// Add post_meta to the database so we can call it.
 		foreach ( $meta as $key => $value ) {

--- a/plugins/tours/tests/phpunit/unit/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/unit/renderTourComments.php
@@ -34,38 +34,29 @@ class Tests_RenderTourComments extends Test_Case {
 	/**
 	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $meta ) {
+	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $tour_comments ) {
 		Functions\expect( 'get_post_meta' )
 			->once()
 			->with( $tour_id, 'tour_comments', true )
-			->andReturn( $meta );
+			->andReturn( $tour_comments );
 
-		if ( ! is_null( $meta ) ) {
-			$this->expectOutputString( $meta );
-		}
-
+		$this->expectOutputString( $tour_comments );
 		render_tour_comments( $tour_id );
 	}
 
 	public function addTestData() {
 		return [
 			'empty postmeta key value'   => [
-				'tour_id'   => 143,
-				'post_meta' => [
-					'tour_comments' => '',
-				]
+				'tour_id'       => 143,
+				'tour_comments' => '',
 			],
 			'postmeta key value1 exists' => [
-				'tour_id'   => 359,
-				'post_meta' => [
-					'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
-				]
+				'tour_id'       => 359,
+				'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
 			],
 			'postmeta key value2 exists' => [
-				'tour_id'   => 502,
-				'post_meta' => [
-					'tour_comments' => 'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY',
-				]
+				'tour_id'       => 502,
+				'tour_comments' => 'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY',
 			]
 		];
 	}

--- a/plugins/tours/tests/phpunit/unit/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/unit/renderTourComments.php
@@ -2,23 +2,22 @@
 /**
  * Tests for render_tour_comments().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
 
 namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
-use Brain\Monkey;
+use Brain\Monkey\Functions;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\render_tour_comments;
 
 /**
- * Class Tests_RenderTourComments
+ * @covers ::\spiralWebDb\CornerstoneTours\render_tour_comments
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Unit
  * @group   tours
  */
 class Tests_RenderTourComments extends Test_Case {
@@ -32,19 +31,28 @@ class Tests_RenderTourComments extends Test_Case {
 		require_once TOURS_ROOT_DIR . '/src/meta.php';
 	}
 
-	/*
-	 * Test render_the_tour_regions() should echo 'tour_comments' when post_meta is available.
+	/**
+	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_tour_comments_when_post_meta_is_available_from_database() {
-		$tour_id     = 359;
-		$tour_comments = 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY';
-		Monkey\Functions\expect( 'get_post_meta' )
+	public function test_should_echo_tour_comments_when_post_meta_is_available_from_database( $post_data ) {
+		Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $tour_id, 'tour_comments', true )
-			->andReturn( $tour_comments );
+			->with( $post_data['tour_id'], 'tour_comments', true )
+			->andReturn( $post_data['tour_comments'] );
 
-		$this->expectOutputString( $tour_id );
-		render_tour_comments( $tour_id );
+		$this->expectOutputString( $post_data['tour_id'] );
+		render_tour_comments( $post_data['tour_id'] );
+	}
+
+	public function addTestData() {
+		return [
+			'init_post_meta' => [
+				'post_data' => [
+					'tour_id'       => 359,
+					'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
+				]
+			]
+		];
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/unit/renderTourComments.php
@@ -34,23 +34,29 @@ class Tests_RenderTourComments extends Test_Case {
 	/**
 	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_tour_comments_when_post_meta_is_available_from_database( $post_data ) {
+	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $postmeta ) {
 		Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $post_data['tour_id'], 'tour_comments', true )
-			->andReturn( $post_data['tour_comments'] );
+			->with( $tour_id, 'tour_comments', true )
+			->andReturn( $postmeta );
 
-		$this->expectOutputString( $post_data['tour_id'] );
-		render_tour_comments( $post_data['tour_id'] );
+		$this->expectOutputString( $tour_id );
+		render_tour_comments( $tour_id );
 	}
 
 	public function addTestData() {
 		return [
-			'init_post_meta' => [
-				'post_data' => [
-					'tour_id'       => 359,
-					'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
-				]
+			'empty postmeta key value'   => [
+				'tour_id'       => 143,
+				'tour_comments' => '',
+			],
+			'postmeta key value1 exists' => [
+				'tour_id'       => 359,
+				'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
+			],
+			'postmeta key value2 exists' => [
+				'tour_id'       => 502,
+				'tour_comments' => 'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY',
 			]
 		];
 	}

--- a/plugins/tours/tests/phpunit/unit/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/unit/renderTourComments.php
@@ -34,13 +34,16 @@ class Tests_RenderTourComments extends Test_Case {
 	/**
 	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $tour_comments ) {
+	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $meta, $expected ) {
 		Functions\expect( 'get_post_meta' )
 			->once()
 			->with( $tour_id, 'tour_comments', true )
-			->andReturn( $tour_comments );
+			->andReturn( $meta );
 
-		$this->expectOutputString( $tour_comments );
+		if ( ! is_null( $expected ) ) {
+			$this->expectOutputString( $expected );
+		}
+
 		render_tour_comments( $tour_id );
 	}
 
@@ -49,14 +52,17 @@ class Tests_RenderTourComments extends Test_Case {
 			'empty postmeta key value'   => [
 				'tour_id'       => 143,
 				'tour_comments' => '',
+				'expected'      => '',
 			],
 			'postmeta key value1 exists' => [
 				'tour_id'       => 359,
 				'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
+				'expected'      => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
 			],
 			'postmeta key value2 exists' => [
 				'tour_id'       => 502,
 				'tour_comments' => 'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY',
+				'expected'      => 'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY',
 			]
 		];
 	}

--- a/plugins/tours/tests/phpunit/unit/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/unit/renderTourComments.php
@@ -34,29 +34,38 @@ class Tests_RenderTourComments extends Test_Case {
 	/**
 	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $postmeta ) {
+	public function test_should_echo_meta_key_values_when_postmeta_exists( $tour_id, $meta ) {
 		Functions\expect( 'get_post_meta' )
 			->once()
 			->with( $tour_id, 'tour_comments', true )
-			->andReturn( $postmeta );
+			->andReturn( $meta );
 
-		$this->expectOutputString( $tour_id );
+		if ( ! is_null( $meta ) ) {
+			$this->expectOutputString( $meta );
+		}
+
 		render_tour_comments( $tour_id );
 	}
 
 	public function addTestData() {
 		return [
 			'empty postmeta key value'   => [
-				'tour_id'       => 143,
-				'tour_comments' => '',
+				'tour_id'   => 143,
+				'post_meta' => [
+					'tour_comments' => '',
+				]
 			],
 			'postmeta key value1 exists' => [
-				'tour_id'       => 359,
-				'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
+				'tour_id'   => 359,
+				'post_meta' => [
+					'tour_comments' => 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY',
+				]
 			],
 			'postmeta key value2 exists' => [
-				'tour_id'       => 502,
-				'tour_comments' => 'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY',
+				'tour_id'   => 502,
+				'post_meta' => [
+					'tour_comments' => 'Note: Performed at Alice Tully Hall, Lincoln Center, New York, NY',
+				]
 			]
 		];
 	}

--- a/plugins/tours/tests/phpunit/unit/renderTourComments.php
+++ b/plugins/tours/tests/phpunit/unit/renderTourComments.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Tests for render_tour_comments().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Unit;
+
+use Brain\Monkey;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\CornerstoneTours\render_tour_comments;
+
+/**
+ * Class Tests_RenderTourComments
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Unit
+ * @group   tours
+ */
+class Tests_RenderTourComments extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once TOURS_ROOT_DIR . '/src/meta.php';
+	}
+
+	/*
+	 * Test render_the_tour_regions() should echo 'tour_comments' when post_meta is available.
+	 */
+	public function test_should_echo_tour_comments_when_post_meta_is_available_from_database() {
+		$tour_id     = 359;
+		$tour_comments = 'Note: Performed in Zankel Hall at Carnegie Hall, New York, NY';
+		Monkey\Functions\expect( 'get_post_meta' )
+			->once()
+			->with( $tour_id, 'tour_comments', true )
+			->andReturn( $tour_comments );
+
+		$this->expectOutputString( $tour_id );
+		render_tour_comments( $tour_id );
+	}
+}
+


### PR DESCRIPTION
## PR Summary

This PR includes one unit and integration test each for the function `render_tour_comments` in the `tours` plugin.  The function gets and echos the post meta `tour_comments` into the HTML view displayed in the title of each past tour.   The unit and integration tests each employ a @dataProvider method to pass test data to their respective test methods.

The relative file path to the function within the plugin is:

> `/tours/src/meta.php`.