### PR TITLE
PR#68 (registerCustomConfigs | add @dataProvider method)

### DIFF
--- a/plugins/faq/src/config-loader.php
+++ b/plugins/faq/src/config-loader.php
@@ -34,7 +34,7 @@ function register_custom_configs( array $configurations ) {
 
 	$runtime_config = (array) require _get_plugin_directory() . '/config/' . $filename . '.php';
 
-	if ( ! $runtime_config ) {
+	if ( empty( $runtime_config ) ) {
 		return $configurations;
 	}
 

--- a/plugins/faq/src/config-loader.php
+++ b/plugins/faq/src/config-loader.php
@@ -32,7 +32,7 @@ function register_custom_configs( array $configurations ) {
 		? 'post-type'
 		: 'taxonomy';
 
-	$runtime_config = (array) require_once _get_plugin_directory() . '/config/' . $filename . '.php';
+	$runtime_config = (array) require _get_plugin_directory() . '/config/' . $filename . '.php';
 
 	if ( ! $runtime_config ) {
 		return $configurations;

--- a/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
@@ -2,9 +2,9 @@
 /**
  * Tests for register_custom_configs().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
@@ -12,89 +12,73 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function has_filter;
 use function spiralWebDb\CornerstoneTours\register_custom_configs;
 
 /**
- * Class Tests_RegisterCustomConfigs
+ * @covers ::\spiralWebDb\CornerstoneTours\register_custom_configs
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Integration
  * @group   tours
- * @group   admin
  */
 class Tests_RegisterCustomConfigs extends Test_Case {
 
-	/*
+	/**
 	 * Test register_custom_configs() is registered to filter 'add_custom_post_type_runtime_config' when event fires.
 	 */
 	public function test_callback_is_registered_to_filter_hook_when_event_fires() {
-		$this->assertTrue( has_filter( 'add_custom_post_type_runtime_config' ) );
 		$this->assertEquals( 7, has_filter( 'add_custom_post_type_runtime_config', 'spiralWebDb\CornerstoneTours\register_custom_configs' ) );
 	}
 
-	/*
-     * Test register_custom_configs() should add a runtime post_type config to existing configs.
+	/**
+	 * @dataProvider addTestData
+	 * @param array $configurations
+	 * @param array $tours
 	 */
-	public function test_should_add_runtime_post_type_config_to_existing_configs() {
-		$configurations      = [];
-		$expected_subarray_1 = [
-			'tours' => [
-				'post_type' => 'tours'
-			]
-		];
-		$expected_subarray_2 = [
-			'tours' => [
-				'labels' => [
-					'singular_label'    => 'Past Tour',
-					'plural_label'      => 'Past Tours',
-					'in_sentance_label' => 'Tours', // The label used within a sentance.
-					'text_domain'       => 'cornerstone-tours',
+	public function test_should_add_runtime_post_type_config_to_existing_configs( array $configurations, array $tours) {
+
+		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
+		$this->assertContains( $tours['post_type'], (array) $tours );
+		$this->assertContains( $tours['features'], (array) $tours );
+		$this->assertContains( $tours['args'], (array) $tours );
+	}
+
+	public function addTestData() {
+		return [
+			'post type config' => [
+				'configurations' => [],
+				'tours'          => [
+					'post_type' => 'tours',
+					'features'  => [
+						'base_post_type' => 'post',
+						'exclude'        => [
+							'excerpt',
+							'comments',
+							'trackbacks',
+	//			            'custom-fields',
+							'thumbnail', // also known as the 'featured image'.
+							'author',
+							'post-formats',
+							'genesis-seo',
+							'genesis-scripts',
+							'genesis-layouts',
+							'genesis-rel-author',
+						],
+						'additional'     => [
+							'page-attributes',
+						],
+					],
+					'args'      => [
+						'description'  => '', // For informational purposes only.
+						'label'        => '',
+						'labels'       => '', // automatically generate the labels.
+						'public'       => true,
+						'show_in_rest' => true,
+						'menu_icon'    => 'dashicons-admin-site',
+						'supports'     => '', // automatically generate the support features.
+						'has_archive'  => true,
+					],
 				]
 			]
 		];
-		$expected_subarray_3 = [
-			'tours' => [
-				'features' => [
-					'base_post_type' => 'post',
-					'exclude'        => [
-						'excerpt',
-						'comments',
-						'trackbacks',
-//			            'custom-fields',
-						'thumbnail', // also known as the 'featured image'.
-						'author',
-						'post-formats',
-						'genesis-seo',
-						'genesis-scripts',
-						'genesis-layouts',
-						'genesis-rel-author',
-					],
-					'additional'     => [
-						'page-attributes',
-					],
-				],
-			]
-		];
-		$expected_subarray_4 = [
-			'tours' => [
-				'args'      => [
-					'description'  => '', // For informational purposes only.
-					'label'        => '',
-					'labels'       => '', // automatically generate the labels.
-					'public'       => true,
-					'show_in_rest' => true,
-					'menu_icon'    => 'dashicons-admin-site',
-					'supports'     => '', // automatically generate the support features.
-					'has_archive'  => true,
-				],
-			]
-		];
-
-		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( $expected_subarray_1, register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( $expected_subarray_2, register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( $expected_subarray_3, register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( $expected_subarray_4, register_custom_configs( (array) $configurations ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for register_custom_configs().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function has_filter;
+use function spiralWebDb\CornerstoneTours\register_custom_configs;
+
+/**
+ * Class Tests_RegisterCustomConfigs
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ * @group   admin
+ */
+class Tests_RegisterCustomConfigs extends Test_Case {
+
+	/*
+	 * Test register_custom_configs() is registered to filter 'add_custom_post_type_runtime_config' when event fires.
+	 */
+	public function test_callback_is_registered_to_filter_hook_when_event_fires() {
+		$this->assertTrue( has_filter( 'add_custom_post_type_runtime_config' ) );
+		$this->assertEquals( 7, has_filter( 'add_custom_post_type_runtime_config', 'spiralWebDb\CornerstoneTours\register_custom_configs' ) );
+	}
+
+	/*
+     * Test register_custom_configs() should add a runtime post_type config to existing configs.
+	 */
+	public function test_should_add_runtime_post_type_config_to_existing_configs() {
+		$configurations = [];
+
+		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( [ 'tours' => [ 'post_type' => 'tours' ] ], register_custom_configs( (array) $configurations ) );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
@@ -12,7 +12,7 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function spiralWebDb\CornerstoneTours\register_custom_configs;
+use function spiralWebDb\CornerstoneTours\_get_plugin_directory;
 
 /**
  * @covers ::\spiralWebDb\CornerstoneTours\register_custom_configs
@@ -21,63 +21,49 @@ use function spiralWebDb\CornerstoneTours\register_custom_configs;
  */
 class Tests_RegisterCustomConfigs extends Test_Case {
 
-	/**
-	 * Test register_custom_configs() is registered to filter 'add_custom_post_type_runtime_config' when event fires.
-	 */
 	public function test_callback_is_registered_to_filter_hook_when_event_fires() {
 		$this->assertEquals( 7, has_filter( 'add_custom_post_type_runtime_config', 'spiralWebDb\CornerstoneTours\register_custom_configs' ) );
 	}
 
 	/**
 	 * @dataProvider addTestData
-	 * @param array $configurations
-	 * @param array $tours
 	 */
-	public function test_should_add_runtime_post_type_config_to_existing_configs( array $configurations, array $tours) {
+	public function test_should_add_runtime_post_type_config_to_existing_configs( array $existing, array $expected ) {
+		$configs = apply_filters( 'add_custom_post_type_runtime_config', $existing );
 
-		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
-		$this->assertContains( $tours['post_type'], (array) $tours );
-		$this->assertContains( $tours['features'], (array) $tours );
-		$this->assertContains( $tours['args'], (array) $tours );
+		$this->assertArrayHasKey( 'tours', $configs );
+		$this->assertSame( $expected, $configs['tours'] );
+
+		foreach ( $existing as $key => $config ) {
+			$this->assertArrayHasKey( $key, $configs );
+			$this->assertSame( $config, $configs[ $key ] );
+		}
 	}
 
 	public function addTestData() {
+		$tours = (array) require _get_plugin_directory() . '/config/post-type.php';
+
 		return [
-			'post type config' => [
-				'configurations' => [],
-				'tours'          => [
-					'post_type' => 'tours',
-					'features'  => [
-						'base_post_type' => 'post',
-						'exclude'        => [
-							'excerpt',
-							'comments',
-							'trackbacks',
-	//			            'custom-fields',
-							'thumbnail', // also known as the 'featured image'.
-							'author',
-							'post-formats',
-							'genesis-seo',
-							'genesis-scripts',
-							'genesis-layouts',
-							'genesis-rel-author',
+			'testShouldIncludToursConfig' => [
+				'existing_configs' => [],
+				'tours'            => $tours,
+			],
+
+			'testShouldMergeToursWithExistinConfigs' => [
+				'existing_configs' => [
+					'ipseum' => [
+						'post_type' => 'ipseum',
+						'labels'    => [
+							'singular_label' => 'Ipseum',
 						],
-						'additional'     => [
-							'page-attributes',
+						'features'  => [
+							'base_post_type' => 'post',
 						],
+						'args'      => [],
 					],
-					'args'      => [
-						'description'  => '', // For informational purposes only.
-						'label'        => '',
-						'labels'       => '', // automatically generate the labels.
-						'public'       => true,
-						'show_in_rest' => true,
-						'menu_icon'    => 'dashicons-admin-site',
-						'supports'     => '', // automatically generate the support features.
-						'has_archive'  => true,
-					],
-				]
-			]
+				],
+				'tours'            => $tours,
+			],
 		];
 	}
 }

--- a/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
@@ -44,12 +44,12 @@ class Tests_RegisterCustomConfigs extends Test_Case {
 		$tours = (array) require _get_plugin_directory() . '/config/post-type.php';
 
 		return [
-			'testShouldIncludToursConfig' => [
+			'testShouldIncludeToursConfig' => [
 				'existing_configs' => [],
 				'tours'            => $tours,
 			],
 
-			'testShouldMergeToursWithExistinConfigs' => [
+			'testShouldMergeToursWithExistingConfigs' => [
 				'existing_configs' => [
 					'ipseum' => [
 						'post_type' => 'ipseum',

--- a/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/integration/registerCustomConfigs.php
@@ -36,10 +36,65 @@ class Tests_RegisterCustomConfigs extends Test_Case {
      * Test register_custom_configs() should add a runtime post_type config to existing configs.
 	 */
 	public function test_should_add_runtime_post_type_config_to_existing_configs() {
-		$configurations = [];
+		$configurations      = [];
+		$expected_subarray_1 = [
+			'tours' => [
+				'post_type' => 'tours'
+			]
+		];
+		$expected_subarray_2 = [
+			'tours' => [
+				'labels' => [
+					'singular_label'    => 'Past Tour',
+					'plural_label'      => 'Past Tours',
+					'in_sentance_label' => 'Tours', // The label used within a sentance.
+					'text_domain'       => 'cornerstone-tours',
+				]
+			]
+		];
+		$expected_subarray_3 = [
+			'tours' => [
+				'features' => [
+					'base_post_type' => 'post',
+					'exclude'        => [
+						'excerpt',
+						'comments',
+						'trackbacks',
+//			            'custom-fields',
+						'thumbnail', // also known as the 'featured image'.
+						'author',
+						'post-formats',
+						'genesis-seo',
+						'genesis-scripts',
+						'genesis-layouts',
+						'genesis-rel-author',
+					],
+					'additional'     => [
+						'page-attributes',
+					],
+				],
+			]
+		];
+		$expected_subarray_4 = [
+			'tours' => [
+				'args'      => [
+					'description'  => '', // For informational purposes only.
+					'label'        => '',
+					'labels'       => '', // automatically generate the labels.
+					'public'       => true,
+					'show_in_rest' => true,
+					'menu_icon'    => 'dashicons-admin-site',
+					'supports'     => '', // automatically generate the support features.
+					'has_archive'  => true,
+				],
+			]
+		];
 
 		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( [ 'tours' => [ 'post_type' => 'tours' ] ], register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( $expected_subarray_1, register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( $expected_subarray_2, register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( $expected_subarray_3, register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( $expected_subarray_4, register_custom_configs( (array) $configurations ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
@@ -45,7 +45,7 @@ class Tests_RegisterCustomConfigs extends Test_Case {
 
 	public function addTestData() {
 		return [
-			'testShouldIncludeToursConfig'            => [
+			'testShouldIncludeToursConfig' => [
 				'existing_configs' => [],
 			],
 		];

--- a/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
@@ -38,12 +38,67 @@ class Tests_RegisterCustomConfigs extends Test_Case {
 	public function test_should_add_runtime_post_type_config_to_existing_configs() {
 		$configurations = [];
 		Monkey\Functions\expect( '_get_plugin_directory' )
-			->twice()
+			->times(5)
 			->with()
 			->andReturn( TOURS_ROOT_DIR );
+		$expected_subarray_1 = [
+			'tours' => [
+				'post_type' => 'tours'
+			]
+		];
+		$expected_subarray_2 = [
+			'tours' => [
+				'labels' => [
+					'singular_label'    => 'Past Tour',
+					'plural_label'      => 'Past Tours',
+					'in_sentance_label' => 'Tours', // The label used within a sentance.
+					'text_domain'       => 'cornerstone-tours',
+				]
+			]
+		];
+		$expected_subarray_3 = [
+			'tours' => [
+				'features' => [
+					'base_post_type' => 'post',
+					'exclude'        => [
+						'excerpt',
+						'comments',
+						'trackbacks',
+//			            'custom-fields',
+						'thumbnail', // also known as the 'featured image'.
+						'author',
+						'post-formats',
+						'genesis-seo',
+						'genesis-scripts',
+						'genesis-layouts',
+						'genesis-rel-author',
+					],
+					'additional'     => [
+						'page-attributes',
+					],
+				],
+			]
+		];
+		$expected_subarray_4 = [
+			'tours' => [
+				'args'      => [
+					'description'  => '', // For informational purposes only.
+					'label'        => '',
+					'labels'       => '', // automatically generate the labels.
+					'public'       => true,
+					'show_in_rest' => true,
+					'menu_icon'    => 'dashicons-admin-site',
+					'supports'     => '', // automatically generate the support features.
+					'has_archive'  => true,
+				],
+			]
+		];
 
 		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( [ 'tours' => [ 'post_type' => 'tours' ] ], register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( $expected_subarray_1, register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( $expected_subarray_2, register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( $expected_subarray_3, register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( $expected_subarray_4, register_custom_configs( (array) $configurations ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
@@ -2,23 +2,22 @@
 /**
  * Tests for register_custom_configs().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
 
 namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
-use Brain\Monkey;
+use Brain\Monkey\Functions;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\register_custom_configs;
 
 /**
- * Class Tests_RegisterCustomConfigs
+ * @covers ::\spiralWebDb\CornerstoneTours\register_custom_configs
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Unit
  * @group   tours
  */
 class Tests_RegisterCustomConfigs extends Test_Case {
@@ -32,73 +31,59 @@ class Tests_RegisterCustomConfigs extends Test_Case {
 		require_once TOURS_ROOT_DIR . '/src/config-loader.php';
 	}
 
-	/*
-	 * Test register_custom_configs() should add a runtime post_type config to existing configs.
+	/**
+	 * @dataProvider addTestData
 	 */
-	public function test_should_add_runtime_post_type_config_to_existing_configs() {
-		$configurations = [];
-		Monkey\Functions\expect( '_get_plugin_directory' )
-			->times(5)
+	public function test_should_add_runtime_post_type_config_to_existing_configs( array $configurations, array $tours ) {
+		Functions\expect( '_get_plugin_directory' )
+			->times( 1 )
 			->with()
 			->andReturn( TOURS_ROOT_DIR );
-		$expected_subarray_1 = [
-			'tours' => [
-				'post_type' => 'tours'
-			]
-		];
-		$expected_subarray_2 = [
-			'tours' => [
-				'labels' => [
-					'singular_label'    => 'Past Tour',
-					'plural_label'      => 'Past Tours',
-					'in_sentance_label' => 'Tours', // The label used within a sentance.
-					'text_domain'       => 'cornerstone-tours',
+
+		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
+		$this->assertContains( $tours['post_type'], (array) $tours );
+		$this->assertContains( $tours['features'], (array) $tours );
+		$this->assertContains( $tours['args'], (array) $tours );
+	}
+
+	public function addTestData() {
+		return [
+			'post type config' => [
+				'configurations' => [],
+				'tours'          => [
+					'post_type' => 'tours',
+					'features'  => [
+						'base_post_type' => 'post',
+						'exclude'        => [
+							'excerpt',
+							'comments',
+							'trackbacks',
+//			            'custom-fields',
+							'thumbnail', // also known as the 'featured image'.
+							'author',
+							'post-formats',
+							'genesis-seo',
+							'genesis-scripts',
+							'genesis-layouts',
+							'genesis-rel-author',
+						],
+						'additional'     => [
+							'page-attributes',
+						],
+					],
+					'args'      => [
+						'description'  => '', // For informational purposes only.
+						'label'        => '',
+						'labels'       => '', // automatically generate the labels.
+						'public'       => true,
+						'show_in_rest' => true,
+						'menu_icon'    => 'dashicons-admin-site',
+						'supports'     => '', // automatically generate the support features.
+						'has_archive'  => true,
+					],
 				]
 			]
 		];
-		$expected_subarray_3 = [
-			'tours' => [
-				'features' => [
-					'base_post_type' => 'post',
-					'exclude'        => [
-						'excerpt',
-						'comments',
-						'trackbacks',
-//			            'custom-fields',
-						'thumbnail', // also known as the 'featured image'.
-						'author',
-						'post-formats',
-						'genesis-seo',
-						'genesis-scripts',
-						'genesis-layouts',
-						'genesis-rel-author',
-					],
-					'additional'     => [
-						'page-attributes',
-					],
-				],
-			]
-		];
-		$expected_subarray_4 = [
-			'tours' => [
-				'args'      => [
-					'description'  => '', // For informational purposes only.
-					'label'        => '',
-					'labels'       => '', // automatically generate the labels.
-					'public'       => true,
-					'show_in_rest' => true,
-					'menu_icon'    => 'dashicons-admin-site',
-					'supports'     => '', // automatically generate the support features.
-					'has_archive'  => true,
-				],
-			]
-		];
-
-		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( $expected_subarray_1, register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( $expected_subarray_2, register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( $expected_subarray_3, register_custom_configs( (array) $configurations ) );
-		$this->assertArraySubset( $expected_subarray_4, register_custom_configs( (array) $configurations ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Tests for register_custom_configs().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Unit;
+
+use Brain\Monkey;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\CornerstoneTours\register_custom_configs;
+
+/**
+ * Class Tests_RegisterCustomConfigs
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Unit
+ * @group   tours
+ */
+class Tests_RegisterCustomConfigs extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once TOURS_ROOT_DIR . '/src/config-loader.php';
+	}
+
+	/*
+	 * Test register_custom_configs() should add a runtime post_type config to existing configs.
+	 */
+	public function test_should_add_runtime_post_type_config_to_existing_configs() {
+		$configurations = [];
+		Monkey\Functions\expect( '_get_plugin_directory' )
+			->twice()
+			->with()
+			->andReturn( TOURS_ROOT_DIR );
+
+		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
+		$this->assertArraySubset( [ 'tours' => [ 'post_type' => 'tours' ] ], register_custom_configs( (array) $configurations ) );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
+++ b/plugins/tours/tests/phpunit/unit/registerCustomConfigs.php
@@ -34,55 +34,20 @@ class Tests_RegisterCustomConfigs extends Test_Case {
 	/**
 	 * @dataProvider addTestData
 	 */
-	public function test_should_add_runtime_post_type_config_to_existing_configs( array $configurations, array $tours ) {
+	public function test_should_add_runtime_post_type_config_to_existing_configs( array $existing ) {
 		Functions\expect( '_get_plugin_directory' )
 			->times( 1 )
 			->with()
 			->andReturn( TOURS_ROOT_DIR );
 
-		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $configurations ) );
-		$this->assertContains( $tours['post_type'], (array) $tours );
-		$this->assertContains( $tours['features'], (array) $tours );
-		$this->assertContains( $tours['args'], (array) $tours );
+		$this->assertArrayHasKey( 'tours', register_custom_configs( (array) $existing ) );
 	}
 
 	public function addTestData() {
 		return [
-			'post type config' => [
-				'configurations' => [],
-				'tours'          => [
-					'post_type' => 'tours',
-					'features'  => [
-						'base_post_type' => 'post',
-						'exclude'        => [
-							'excerpt',
-							'comments',
-							'trackbacks',
-//			            'custom-fields',
-							'thumbnail', // also known as the 'featured image'.
-							'author',
-							'post-formats',
-							'genesis-seo',
-							'genesis-scripts',
-							'genesis-layouts',
-							'genesis-rel-author',
-						],
-						'additional'     => [
-							'page-attributes',
-						],
-					],
-					'args'      => [
-						'description'  => '', // For informational purposes only.
-						'label'        => '',
-						'labels'       => '', // automatically generate the labels.
-						'public'       => true,
-						'show_in_rest' => true,
-						'menu_icon'    => 'dashicons-admin-site',
-						'supports'     => '', // automatically generate the support features.
-						'has_archive'  => true,
-					],
-				]
-			]
+			'testShouldIncludeToursConfig'            => [
+				'existing_configs' => [],
+			],
 		];
 	}
 }


### PR DESCRIPTION
## PR Summary

This PR includes one unit and two integration tests for the function `render_custom_configs` in the `tours` plugin. The function loads in the post_type runtime configurations using the Custom module located in `/mu-plugins/central-hub`. Each principal unit & integration test method accepts parameters from an  @dataProvider test method. 

The relative file path to the function within the plugin is:

> `/tours/src/config-loader.php`.