### PR TITLE
PR#69 (loadConfigurations)

### DIFF
--- a/plugins/tours/tests/phpunit/integration/loadConfigurations.php
+++ b/plugins/tours/tests/phpunit/integration/loadConfigurations.php
@@ -12,7 +12,8 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function spiralWebDb\Metadata\load_configurations;
+use function KnowTheCode\ConfigStore\getConfig;
+use function spiralWebDb\CornerstoneTours\load_configurations;
 
 /**
  * Class Tests_LoadConfigurations
@@ -23,4 +24,19 @@ use function spiralWebDb\Metadata\load_configurations;
  */
 class Tests_LoadConfigurations extends Test_Case {
 
+	/*
+	 * Test load_configurations() should load the 'tours' plugin meta-box configuration.
+	 */
+	public function test_should_load_plugin_meta_box_config() {
+		load_configurations();
+
+		$actual_config = getConfig( 'meta_box.tours' );
+		$this->assertArrayHasKey( 'add_meta_box', $actual_config );
+		$this->assertArrayHasKey( 'custom_fields', $actual_config );
+		$this->assertArrayHasKey( 'view', $actual_config );
+
+		// Clean up.
+		self::remove_from_store( 'meta_box.tours' );
+	}
 }
+

--- a/plugins/tours/tests/phpunit/integration/loadConfigurations.php
+++ b/plugins/tours/tests/phpunit/integration/loadConfigurations.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Tests for load_configurations().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function spiralWebDb\Metadata\load_configurations;
+
+/**
+ * Class Tests_LoadConfigurations
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ * @group   admin
+ */
+class Tests_LoadConfigurations extends Test_Case {
+
+}

--- a/plugins/tours/tests/phpunit/unit/loadConfigurations.php
+++ b/plugins/tours/tests/phpunit/unit/loadConfigurations.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Tests for load_configurations().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Unit;
+
+use Brain\Monkey;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\Metadata\load_configurations;
+
+/**
+ * Class Tests_LoadConfigurations
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Unit
+ * @group   tours
+ */
+class Tests_LoadConfigurations extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once TOURS_ROOT_DIR . '/src/config-loader.php';
+	}
+}

--- a/plugins/tours/tests/phpunit/unit/loadConfigurations.php
+++ b/plugins/tours/tests/phpunit/unit/loadConfigurations.php
@@ -13,7 +13,7 @@ namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
 use Brain\Monkey;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
-use function spiralWebDb\Metadata\load_configurations;
+use function spiralWebDb\CornerstoneTours\load_configurations;
 
 /**
  * Class Tests_LoadConfigurations
@@ -29,6 +29,24 @@ class Tests_LoadConfigurations extends Test_Case {
 	protected function setUp() {
 		parent::setUp();
 
+		Monkey\Functions\expect( '_get_plugin_directory' )
+			->once()
+			->with()
+			->andReturn( TOURS_ROOT_DIR );
+
 		require_once TOURS_ROOT_DIR . '/src/config-loader.php';
 	}
+
+	/*
+	 * Test load_configurations() should load the meta-box configuration from the plugin 'config' directory.
+	 */
+	public function test_should_load_meta_box_config_from_plugin_config_directory() {
+		Monkey\Functions\expect( 'spiralWebDB\Metadata\autoload_configurations' )
+			->once()
+			->with( [ TOURS_ROOT_DIR . '/config/tours.php' ] )
+			->andReturn();
+
+//		$this->assertArrayHasKey( 'meta_box.tours', load_configurations() );
+	}
 }
+

--- a/plugins/tours/tests/phpunit/unit/loadConfigurations.php
+++ b/plugins/tours/tests/phpunit/unit/loadConfigurations.php
@@ -29,24 +29,19 @@ class Tests_LoadConfigurations extends Test_Case {
 	protected function setUp() {
 		parent::setUp();
 
-		Monkey\Functions\expect( '_get_plugin_directory' )
-			->once()
-			->with()
-			->andReturn( TOURS_ROOT_DIR );
-
 		require_once TOURS_ROOT_DIR . '/src/config-loader.php';
 	}
 
 	/*
-	 * Test load_configurations() should load the meta-box configuration from the plugin 'config' directory.
+	 * Test load_configurations() should load the 'tours' plugin meta-box configuration.
 	 */
-	public function test_should_load_meta_box_config_from_plugin_config_directory() {
-		Monkey\Functions\expect( 'spiralWebDB\Metadata\autoload_configurations' )
-			->once()
-			->with( [ TOURS_ROOT_DIR . '/config/tours.php' ] )
-			->andReturn();
+	public function test_should_load_plugin_meta_box_config() {
+		Monkey\Functions\when( '_get_plugin_directory' )->justReturn( TOURS_ROOT_DIR );
 
-//		$this->assertArrayHasKey( 'meta_box.tours', load_configurations() );
+		load_configurations();
+
+		// This is a placeholder to avoid PHPUnit error.
+		$this->assertTrue( true );
 	}
 }
 


### PR DESCRIPTION
## PR Summary 

This PR contains unit and integration tests for the function `load_configurations()` in the `tours` plugin. The function under test loads a meta-box configuration array in the `tours` plugin using the Custom module in `mu-plugins/central-hub`. 

The relative file path to the plugin is: 

>`/tours/config-loader.php`. 
