### PR TITLE
PR#70 (registerTheTemplateFiles)

### DIFF
--- a/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
@@ -24,11 +24,10 @@ use function spiralWebDb\CornerstoneTours\register_the_template_files;
  */
 class Tests_RegisterTheTemplateFiles extends Test_Case {
 
-	/*
+	/**
 	 * Test register_the_template_files() is registered to filter 'register_templates_with_template_loader' when event fires.
 	 */
 	public function test_callback_is_registered_to_filter_hook_when_event_fires() {
-		$this->assertTrue( has_filter( 'register_templates_with_template_loader' ) );
 		$this->assertEquals( 10, has_filter( 'register_templates_with_template_loader', 'spiralWebDb\CornerstoneTours\register_the_template_files' ) );
 	}
 

--- a/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Tests for register_the_template_files().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function has_filter;
+use function spiralWebDb\CornerstoneTours\register_the_template_files;
+
+/**
+ * Class Tests_RegisterTheTemplateFiles
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ * @group   admin
+ */
+class Tests_RegisterTheTemplateFiles extends Test_Case {
+
+	/*
+	 * Test register_the_template_files() is registered to filter 'register_templates_with_template_loader' when event fires.
+	 */
+	public function test_callback_is_registered_to_filter_hook_when_event_fires() {
+		$this->assertTrue( has_filter( 'register_templates_with_template_loader' ) );
+		$this->assertEquals( 10, has_filter( 'register_templates_with_template_loader', 'spiralWebDb\CornerstoneTours\register_the_template_files' ) );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
@@ -12,7 +12,6 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function has_filter;
 use function spiralWebDb\CornerstoneTours\_get_plugin_directory;
 use function spiralWebDb\CornerstoneTours\register_the_template_files;
 

--- a/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
@@ -13,6 +13,7 @@ namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 use function has_filter;
+use function spiralWebDb\CornerstoneTours\_get_plugin_directory;
 use function spiralWebDb\CornerstoneTours\register_the_template_files;
 
 /**
@@ -30,6 +31,18 @@ class Tests_RegisterTheTemplateFiles extends Test_Case {
 	public function test_callback_is_registered_to_filter_hook_when_event_fires() {
 		$this->assertTrue( has_filter( 'register_templates_with_template_loader' ) );
 		$this->assertEquals( 10, has_filter( 'register_templates_with_template_loader', 'spiralWebDb\CornerstoneTours\register_the_template_files' ) );
+	}
+
+	/*
+     * Test register_the_template_files() should return template files when given valid path to plugin config.
+     */
+	public function test_should_return_template_files_given_valid_path_to_plugin_config() {
+		$templates = [];
+
+		$this->assertArrayHasKey( 'single', register_the_template_files( (array) $templates ) );
+		$this->assertArraySubset( [ 'single' => [ 'tours' => _get_plugin_directory() . '/src/template/single-tours.php' ] ], register_the_template_files( (array) $templates ) );
+		$this->assertArrayHasKey( 'post_type_archive', register_the_template_files( (array) $templates ) );
+		$this->assertArraySubset( [ 'post_type_archive' => [ 'tours' => _get_plugin_directory() . '/src/template/archive-tours.php' ] ], register_the_template_files( (array) $templates ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
@@ -25,22 +25,35 @@ use function spiralWebDb\CornerstoneTours\register_the_template_files;
 class Tests_RegisterTheTemplateFiles extends Test_Case {
 
 	/**
-	 * Test register_the_template_files() is registered to filter 'register_templates_with_template_loader' when event fires.
+	 * Test register_the_template_files() is registered to filter 'register_templates_with_template_loader' when event
+	 * fires.
 	 */
 	public function test_callback_is_registered_to_filter_hook_when_event_fires() {
 		$this->assertEquals( 10, has_filter( 'register_templates_with_template_loader', 'spiralWebDb\CornerstoneTours\register_the_template_files' ) );
 	}
 
-	/*
-     * Test register_the_template_files() should return template files when given valid path to plugin config.
-     */
-	public function test_should_return_template_files_given_valid_path_to_plugin_config() {
-		$templates = [];
+	/**
+	 * Test register_the_template_files() should return an array of configuration template files when given an empty templates array.
+	 */
+	public function test_should_return_an_array_of_configuration_template_files_given_an_empty_templates_array() {
+		$config = require _get_plugin_directory() . '/config/templates.php';
 
-		$this->assertArrayHasKey( 'single', register_the_template_files( (array) $templates ) );
-		$this->assertArraySubset( [ 'single' => [ 'tours' => _get_plugin_directory() . '/src/template/single-tours.php' ] ], register_the_template_files( (array) $templates ) );
-		$this->assertArrayHasKey( 'post_type_archive', register_the_template_files( (array) $templates ) );
-		$this->assertArraySubset( [ 'post_type_archive' => [ 'tours' => _get_plugin_directory() . '/src/template/archive-tours.php' ] ], register_the_template_files( (array) $templates ) );
+		$this->assertSame( $config, register_the_template_files( [] ) );
+	}
+
+	/**
+	 * Test register_the_template_files() should return a merged array of configuration template files when given a templates array.
+	 */
+	public function test_should_return_a_merged_array_of_config_template_files_when_given_a_templates_array()   {
+		$templates = [
+			'single' => [
+				'baz' => __DIR__ . '/baz/templates.php',
+			]
+		];
+		$config = require _get_plugin_directory() . '/config/templates.php';
+
+		$this->assertSame( array_merge_recursive( $templates, $config ), register_the_template_files( (array) $templates ) );
 	}
 }
+
 

--- a/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
@@ -13,7 +13,6 @@ namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
 use Brain\Monkey;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
-use function spiralWebDb\CornerstoneTours\_get_plugin_directory;
 use function spiralWebDb\CornerstoneTours\register_the_template_files;
 
 /**
@@ -33,22 +32,53 @@ class Tests_RegisterTheTemplateFiles extends Test_Case {
 		require_once TOURS_ROOT_DIR . '/src/config-loader.php';
 	}
 
-	/*
-	 * Test register_the_template_files() should return template files when given valid path to plugin config.
+	/**
+	 * Test register_the_template_files() should return an array of configuration template files when given an empty
+	 * templates array.
 	 */
-	public function test_should_return_template_files_given_valid_path_to_plugin_config() {
-		$templates = [];
-		// _get_plugin_directory() is called 3 times when register_the_template_files() is invoked.
-		// _get_plugin_directory() is called an additional time when the assertArraySubset() method is run.
+	public function test_should_return_an_array_of_configuration_template_files_given_an_empty_templates_array() {
 		Monkey\Functions\expect( 'spiralWebDb\CornerstoneTours\_get_plugin_directory' )
-			->times( 14 )
+			->times( 3 )
 			->with()
 			->andReturn( TOURS_ROOT_DIR );
+		$templates = [];
+		$config = [
+			'single' => [
+				'tours' => TOURS_ROOT_DIR . '/src/template/single-tours.php',
+			],
+			'post_type_archive' => [
+				'tours' => TOURS_ROOT_DIR . '/src/template/archive-tours.php',
+			],
+		];
 
-		$this->assertArrayHasKey( 'single', register_the_template_files( (array) $templates ) );
-		$this->assertArraySubset( [ 'single' => [ 'tours' => _get_plugin_directory() . '/src/template/single-tours.php' ] ], register_the_template_files( (array) $templates ) );
-		$this->assertArrayHasKey( 'post_type_archive', register_the_template_files( (array) $templates ) );
-		$this->assertArraySubset( [ 'post_type_archive' => [ 'tours' => _get_plugin_directory() . '/src/template/archive-tours.php' ] ], register_the_template_files( (array) $templates ) );
+		$this->assertSame( $config, register_the_template_files( (array) $templates ) );
+	}
+
+	/**
+	 * Test register_the_template_files() should return a merged array of configuration template files when given a templates array.
+	 */
+	public function test_should_return_a_merged_array_of_config_template_files_when_given_a_templates_array()   {
+		Monkey\Functions\expect( 'spiralWebDb\CornerstoneTours\_get_plugin_directory' )
+			->times( 3 )
+			->with()
+			->andReturn( TOURS_ROOT_DIR );
+		$templates = [
+			'single' => [
+				'baz' => __DIR__ . '/baz/templates.php',
+			]
+		];
+		$config = [
+			'single' => [
+				'tours' => TOURS_ROOT_DIR . '/src/template/single-tours.php',
+			],
+			'post_type_archive' => [
+				'tours' => TOURS_ROOT_DIR . '/src/template/archive-tours.php',
+			],
+		];
+
+		$this->assertSame( array_merge_recursive( $templates, $config ), register_the_template_files( (array) $templates ) );
 	}
 }
+
+
 

--- a/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
@@ -13,6 +13,7 @@ namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
 use Brain\Monkey;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\CornerstoneTours\_get_plugin_directory;
 use function spiralWebDb\CornerstoneTours\register_the_template_files;
 
 /**
@@ -38,13 +39,16 @@ class Tests_RegisterTheTemplateFiles extends Test_Case {
 	public function test_should_return_template_files_given_valid_path_to_plugin_config() {
 		$templates = [];
 		// _get_plugin_directory() is called 3 times when register_the_template_files() is invoked.
+		// _get_plugin_directory() is called an additional time when the assertArraySubset() method is run.
 		Monkey\Functions\expect( 'spiralWebDb\CornerstoneTours\_get_plugin_directory' )
-			->times( 6 )
+			->times( 14 )
 			->with()
 			->andReturn( TOURS_ROOT_DIR );
 
 		$this->assertArrayHasKey( 'single', register_the_template_files( (array) $templates ) );
+		$this->assertArraySubset( [ 'single' => [ 'tours' => _get_plugin_directory() . '/src/template/single-tours.php' ] ], register_the_template_files( (array) $templates ) );
 		$this->assertArrayHasKey( 'post_type_archive', register_the_template_files( (array) $templates ) );
+		$this->assertArraySubset( [ 'post_type_archive' => [ 'tours' => _get_plugin_directory() . '/src/template/archive-tours.php' ] ], register_the_template_files( (array) $templates ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Tests for register_the_template_files().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Unit;
+
+use Brain\Monkey;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\CornerstoneTours\register_the_template_files;
+
+/**
+ * Class Tests_RegisterTheTemplateFiles
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Unit
+ * @group   tours
+ */
+class Tests_RegisterTheTemplateFiles extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once TOURS_ROOT_DIR . '/src/config-loader.php';
+	}
+
+	/*
+	 * Test register_the_template_files() should return template files when given valid path to plugin config.
+	 */
+	public function test_should_return_template_files_given_valid_path_to_plugin_config() {
+		$templates = [];
+		// _get_plugin_directory() is called 3 times when register_the_template_files() is invoked.
+		Monkey\Functions\expect( 'spiralWebDb\CornerstoneTours\_get_plugin_directory' )
+			->times( 6 )
+			->with()
+			->andReturn( TOURS_ROOT_DIR );
+
+		$this->assertArrayHasKey( 'single', register_the_template_files( (array) $templates ) );
+		$this->assertArrayHasKey( 'post_type_archive', register_the_template_files( (array) $templates ) );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
@@ -80,5 +80,3 @@ class Tests_RegisterTheTemplateFiles extends Test_Case {
 	}
 }
 
-
-


### PR DESCRIPTION
## PR Summary

This PR contains unit and integration tests for the function `register_the_template_files()` in the `tours` plugin. The function under test loads the template file configuration array in the `tours` plugin using the Template module in `mu-plugins/central-hub`.

The relative file path to the plugin is:

    /tours/config-loader.php.
