### PR TITLE
[WIP]PR#71 (setPastToursByOrderNumber)

### DIFF
--- a/plugins/tours/src/plugin.php
+++ b/plugins/tours/src/plugin.php
@@ -20,9 +20,11 @@ add_action( 'pre_get_posts', __NAMESPACE__ . '\set_past_tours_by_order_number' )
  * @param WP_Query $query Instance of the query.
  */
 function set_past_tours_by_order_number( $query ) {
-
-	if ( is_post_type_archive() ) {
-		$query->set( 'orderby', 'menu_order' );
-		$query->set( 'order', 'DESC' );
+	if ( ! is_post_type_archive( $post_types = 'tours' ) )  {
+		return $query;
 	}
+
+	$query->set( 'orderby', 'menu_order' );
+	$query->set( 'order', 'DESC' );
 }
+

--- a/plugins/tours/src/plugin.php
+++ b/plugins/tours/src/plugin.php
@@ -20,7 +20,7 @@ add_action( 'pre_get_posts', __NAMESPACE__ . '\set_past_tours_by_order_number' )
  * @param WP_Query $query Instance of the query.
  */
 function set_past_tours_by_order_number( $query ) {
-	if ( ! is_post_type_archive( $post_types = 'tours' ) )  {
+	if ( ! is_post_type_archive( 'tours' ) ) {
 		return $query;
 	}
 

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -25,6 +25,20 @@ use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
  */
 class Tests_SetPastToursByOrderNumber extends Test_Case {
 
+	/**
+	 * Instance of WP_Query for each test.
+	 *
+	 * @var object WP_Query
+	 */
+	protected $query;
+
+	/**
+	 * Query vars, after parsing
+	 *
+	 * @var array
+	 */
+	public $query_vars = array();
+
 	/*
 	 * Test set_past_tours_by_order_number() is registered to do_action_ref_array( 'pre_get_posts' ) when event fires.
 	 */
@@ -38,7 +52,7 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
      */
 	public function test_should_return_unmodified_query_when_post_type_is_post() {
 		// Create and get a post object for 'post' post_type with WordPress' factory method.
-		$post  = self::factory()->post->create_and_get();
+		$post = self::factory()->post->create_and_get();
 		// Instantiate a new WP_Query object.
 		$query = new WP_Query();
 
@@ -46,5 +60,23 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 		$this->assertSame( $query, set_past_tours_by_order_number( $query ) );
 	}
 
+	/*
+ * Test set_past_tours_by_order_number() should return modified query object from WP_Query when post_type_is 'tours'.
+ */
+	public function test_should_return_modified_query_when_post_type_is_tours() {
+		// Create and get a post object for 'post' post_type with WordPress' factory method.
+		$post = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
+		// Instantiate a new WP_Query object.
+		$query = new WP_Query();
+		$query->query_vars( [ 'orderby' => 'menu_order', 'order' => 'DESC' ] );
+		
+		set_past_tours_by_order_number( $query );
+
+		// When post_type is 'tours', $query object should contain updated query_vars.
+		$this->assertContains( $query->query_vars( [ 'orderby' ] ), $query );
+		$this->assertContains( $query->query_vars( [ 'order' ] ), $query );
+	}
 }
+
+
 

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -77,5 +77,3 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 	}
 }
 
-
-

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -13,6 +13,7 @@ namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 use function has_action;
+use WP_Query;
 use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
 
 /**
@@ -30,6 +31,19 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 	public function test_callback_is_registered_to_action_hook_when_event_fires() {
 		$this->assertTrue( has_action( 'pre_get_posts' ) );
 		$this->assertEquals( 10, has_action( 'pre_get_posts', 'spiralWebDb\CornerstoneTours\set_past_tours_by_order_number' ) );
+	}
+
+	/*
+     * Test set_past_tours_by_order_number() should return unmodified query object from WP_Query when post_type_is 'post'.
+     */
+	public function test_should_return_unmodified_query_when_post_type_is_post() {
+		// Create and get a post object for 'post' post_type with WordPress' factory method.
+		$post  = self::factory()->post->create_and_get();
+		// Instantiate a new WP_Query object.
+		$query = new WP_Query();
+
+		// When post_type is 'post', there should be no change to the $query object.
+		$this->assertSame( $query, set_past_tours_by_order_number( $query ) );
 	}
 
 }

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -24,21 +24,7 @@ use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
  * @group   admin
  */
 class Tests_SetPastToursByOrderNumber extends Test_Case {
-
-	/**
-	 * Instance of WP_Query for each test.
-	 *
-	 * @var object WP_Query
-	 */
-	protected $query;
-
-	/**
-	 * Query vars, after parsing
-	 *
-	 * @var array
-	 */
-	public $query_vars = array();
-
+	
 	/**
 	 * Test set_past_tours_by_order_number() is registered to do_action_ref_array( 'pre_get_posts' ) when event fires.
 	 */

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -47,20 +47,27 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 	}
 
 	/**
-     * Test set_past_tours_by_order_number() should return modified query object from WP_Query when post_type_is 'tours'.
-     */
-	public function test_should_return_modified_query_when_post_type_is_tours() {
-		// Create and get a post object for 'post' post_type with WordPress' factory method.
-		$post = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
-		// Instantiate a new WP_Query object.
-		$query = new WP_Query();
-		$query->query_vars( [ 'orderby' => 'menu_order', 'order' => 'DESC' ] );
-		
-		set_past_tours_by_order_number( $query );
+	 * Test set_past_tours_by_order_number() should return tours in DESC order by each tour's menu_order.
+	 */
+	public function test_should_return_tours_in_desc_order_menu_order() {
+		$post_ids       = [];
+		$expected_order = [
+			0 => 4,
+			1 => 3,
+			2 => 2,
+			3 => 1,
+		];
+		foreach ( $expected_order as $order => $menu_order ) {
+			$post_ids[ $order ] = $this->factory()->post->create(
+				[
+					'post_type'  => 'tours',
+					'menu_order' => $menu_order,
+				]
+			);
+		}
+		$this->go_to( '?post_type=tours' );
 
-		// When post_type is 'tours', $query object should contain updated query_vars.
-		$this->assertContains( $query->query_vars( [ 'orderby' ] ), $query );
-		$this->assertContains( $query->query_vars( [ 'order' ] ), $query );
+		$this->assertEqualSets( $post_ids, wp_list_pluck( $GLOBALS['wp_query']->posts, 'ID' ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -12,9 +12,6 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function has_action;
-use WP_Query;
-use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
 
 /**
  * Class Tests_SetPastToursByOrderNumber
@@ -24,7 +21,7 @@ use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
  * @group   admin
  */
 class Tests_SetPastToursByOrderNumber extends Test_Case {
-	
+
 	/**
 	 * Test set_past_tours_by_order_number() is registered to do_action_ref_array( 'pre_get_posts' ) when event fires.
 	 */

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -39,29 +39,16 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 	 */
 	public $query_vars = array();
 
-	/*
+	/**
 	 * Test set_past_tours_by_order_number() is registered to do_action_ref_array( 'pre_get_posts' ) when event fires.
 	 */
 	public function test_callback_is_registered_to_action_hook_when_event_fires() {
 		$this->assertEquals( 10, has_action( 'pre_get_posts', 'spiralWebDb\CornerstoneTours\set_past_tours_by_order_number' ) );
 	}
 
-	/*
-     * Test set_past_tours_by_order_number() should return unmodified query object from WP_Query when post_type_is 'post'.
+	/**
+     * Test set_past_tours_by_order_number() should return modified query object from WP_Query when post_type_is 'tours'.
      */
-	public function test_should_return_unmodified_query_when_post_type_is_post() {
-		// Create and get a post object for 'post' post_type with WordPress' factory method.
-		$post = self::factory()->post->create_and_get();
-		// Instantiate a new WP_Query object.
-		$query = new WP_Query();
-
-		// When post_type is 'post', there should be no change to the $query object.
-		$this->assertSame( $query, set_past_tours_by_order_number( $query ) );
-	}
-
-	/*
- * Test set_past_tours_by_order_number() should return modified query object from WP_Query when post_type_is 'tours'.
- */
 	public function test_should_return_modified_query_when_post_type_is_tours() {
 		// Create and get a post object for 'post' post_type with WordPress' factory method.
 		$post = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Tests for set_past_tours_by_order_number().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function has_action;
+use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
+
+/**
+ * Class Tests_SetPastToursByOrderNumber
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Integration
+ * @group   tours
+ * @group   admin
+ */
+class Tests_SetPastToursByOrderNumber extends Test_Case {
+
+	/*
+	 * Test set_past_tours_by_order_number() is registered to do_action_ref_array( 'pre_get_posts' ) when event fires.
+	 */
+	public function test_callback_is_registered_to_action_hook_when_event_fires() {
+		$this->assertTrue( has_action( 'pre_get_posts' ) );
+		$this->assertEquals( 10, has_action( 'pre_get_posts', 'spiralWebDb\CornerstoneTours\set_past_tours_by_order_number' ) );
+	}
+
+}
+

--- a/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/integration/setPastToursByOrderNumber.php
@@ -43,7 +43,6 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 	 * Test set_past_tours_by_order_number() is registered to do_action_ref_array( 'pre_get_posts' ) when event fires.
 	 */
 	public function test_callback_is_registered_to_action_hook_when_event_fires() {
-		$this->assertTrue( has_action( 'pre_get_posts' ) );
 		$this->assertEquals( 10, has_action( 'pre_get_posts', 'spiralWebDb\CornerstoneTours\set_past_tours_by_order_number' ) );
 	}
 

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests for set_past_tours_by_order_number().
+ *
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
+ * @since       1.0.0
+ * @author      Robert Gadon <rgadon107>
+ * @link        https://github.com/rgadon107/cornerstone
+ * @license     GNU-2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Unit;
+
+use Mockery as m;
+use Brain\Monkey;
+use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
+use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
+
+/**
+ * Class Tests_SetPastToursByOrderNumber
+ *
+ * @package spiralWebDb\CornerstoneTours\Tests\Unit
+ * @group   tours
+ */
+class Tests_SetPastToursByOrderNumber extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once TOURS_ROOT_DIR . '/src/plugin.php';
+	}
+
+	/*
+     * Test set_past_tours_by_order_number() should return unmodified query_vars from WP_Query when post_type_archive is false.
+     */
+	public function test_should_return_unmodified_query_vars_when_post_type_archive_is_false() {
+		$expected = $this->query = (object) [
+			'query_vars' => [
+				'order' => "ASC",
+			]
+		];
+		Monkey\Functions\expect( 'is_post_type_archive' )
+			->once()
+			->with()
+			->andReturn( false );
+
+		$this->assertContains( $expected, set_past_tours_by_order_number( $this->query ) );
+	}
+
+	/*
+	 * Test set_past_tours_by_order_number() should modify query_var default when post_type_archive is true.
+	 */
+	public function test_should_modify_query_var_default_when_post_type_archive_is_true() {
+		Monkey\Functions\expect( 'is_post_type_archive' )
+			->once()
+			->with()
+			->andReturn( true );
+		Monkey\Functions\expect( 'set')
+			->once()
+			->with( 'order', 'DESC')
+			->andReturnValues( 'DESC');
+
+		set_past_tours_by_order_number( $this->query );
+	}
+}
+

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -25,45 +25,64 @@ use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
 class Tests_SetPastToursByOrderNumber extends Test_Case {
 
 	/**
+	 * Instance of WP_Query for each test.
+	 *
+	 * @var Mockery
+	 */
+	protected $query;
+
+	/**
+	 * Query vars, after parsing
+	 *
+	 * @var array
+	 */
+	public $query_vars = array();
+
+	/**
 	 * Prepares the test environment before each test.
 	 */
 	protected function setUp() {
 		parent::setUp();
 
 		require_once TOURS_ROOT_DIR . '/src/plugin.php';
+
+		$this->query             = m::mock( 'WP_Query' );
+		$this->query->query_vars = [
+			'order'   => 'ASC',
+			'orderby' => 'menu_order'
+		];
 	}
 
 	/*
      * Test set_past_tours_by_order_number() should return unmodified query_vars from WP_Query when post_type_archive is false.
      */
 	public function test_should_return_unmodified_query_vars_when_post_type_archive_is_false() {
-		$expected = $this->query = (object) [
-			'query_vars' => [
-				'order' => "ASC",
-			]
-		];
+		$expected = $this->query->query_vars;
+
 		Monkey\Functions\expect( 'is_post_type_archive' )
 			->once()
 			->with()
 			->andReturn( false );
 
-		$this->assertContains( $expected, set_past_tours_by_order_number( $this->query ) );
+		set_past_tours_by_order_number( $this->query );
+
+		$this->assertSame( $expected, $this->query->query_vars );
 	}
 
 	/*
 	 * Test set_past_tours_by_order_number() should modify query_var default when post_type_archive is true.
 	 */
-	public function test_should_modify_query_var_default_when_post_type_archive_is_true() {
-		Monkey\Functions\expect( 'is_post_type_archive' )
-			->once()
-			->with()
-			->andReturn( true );
-		Monkey\Functions\expect( 'set')
-			->once()
-			->with( 'order', 'DESC')
-			->andReturnValues( 'DESC');
-
-		set_past_tours_by_order_number( $this->query );
-	}
+//	public function test_should_modify_query_var_default_when_post_type_archive_is_true() {
+//		Monkey\Functions\expect( 'is_post_type_archive' )
+//			->once()
+//			->with()
+//			->andReturn( true );
+//		Monkey\Functions\expect( 'set' )
+//			->once()
+//			->with( 'order', 'DESC' )
+//			->andReturnValues( 'DESC' );
+//
+//		set_past_tours_by_order_number( $this->query );
+//	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -71,6 +71,7 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 				      $this->setQueryVar( $query, $key, $value );
 			      }
 		      );
+
 		$query->shouldReceive( 'set' )
 		      ->once()
 		      ->with( 'order', 'DESC' )

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -23,7 +23,7 @@ use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
  * @group   tours
  */
 class Tests_SetPastToursByOrderNumber extends Test_Case {
-	
+
 	/**
 	 * Prepares the test environment before each test.
 	 */
@@ -32,21 +32,21 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 
 		require_once TOURS_ROOT_DIR . '/src/plugin.php';
 
-		$query = m::mock( 'WP_Query' );
+		$this->query = m::mock( 'WP_Query' );
 	}
 
 	/*
      * Test set_past_tours_by_order_number() should return unmodified query_vars from WP_Query when post_type_archive is false.
      */
 	public function test_should_return_unmodified_query_vars_when_post_type_archive_is_false() {
-		$expected = $query;
+		$expected = $this->query;
 
 		Monkey\Functions\expect( 'is_post_type_archive' )
 			->once()
-			->with()
+			->with( 'tours')
 			->andReturn( false );
 
-		$this->assertSame( $expected, set_past_tours_by_order_number( $query ) );
+		$this->assertSame( $expected, set_past_tours_by_order_number( $this->query ) );
 	}
 
 	/*
@@ -57,20 +57,20 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 			->once()
 			->with( 'tours' )
 			->andReturn( true );
-		$query->shouldReceive( 'set' )
+		$this->query->shouldReceive( 'set' )
 		      ->once()
 		      ->with( 'orderby', 'menu_order' )
 		      ->andReturn();
-		$query->shouldReceive( 'set' )
+		$this->query->shouldReceive( 'set' )
 		      ->once()
 		      ->with( 'order', 'DESC' )
 		      ->andReturn();
-		$expected = $query->query_vars = [
+		$expected = $this->query->query_vars = [
 			'order'   => 'ASC',
 			'orderby' => 'menu_order'
 		];
 
-		$this->assertSame( $expected, set_past_tours_by_order_number( $query ) );
+		$this->assertSame( $expected, set_past_tours_by_order_number( $this->query ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -23,21 +23,7 @@ use function spiralWebDb\CornerstoneTours\set_past_tours_by_order_number;
  * @group   tours
  */
 class Tests_SetPastToursByOrderNumber extends Test_Case {
-
-	/**
-	 * Instance of WP_Query for each test.
-	 *
-	 * @var Mockery
-	 */
-	protected $query;
-
-	/**
-	 * Query vars, after parsing
-	 *
-	 * @var array
-	 */
-	public $query_vars = array();
-
+	
 	/**
 	 * Prepares the test environment before each test.
 	 */

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -46,27 +46,21 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 
 		require_once TOURS_ROOT_DIR . '/src/plugin.php';
 
-		$query             = m::mock( 'WP_Query' );
-		$query->query_vars = [
-			'order'   => 'ASC',
-			'orderby' => 'menu_order'
-		];
+		$query = m::mock( 'WP_Query' );
 	}
 
 	/*
      * Test set_past_tours_by_order_number() should return unmodified query_vars from WP_Query when post_type_archive is false.
      */
 	public function test_should_return_unmodified_query_vars_when_post_type_archive_is_false() {
-		$expected = $query->query_vars;
+		$expected = $query;
 
 		Monkey\Functions\expect( 'is_post_type_archive' )
 			->once()
 			->with()
 			->andReturn( false );
 
-		set_past_tours_by_order_number( $query );
-
-		$this->assertSame( $expected, $query->query_vars );
+		$this->assertSame( $expected, set_past_tours_by_order_number( $query ) );
 	}
 
 	/*
@@ -75,18 +69,22 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 	public function test_should_modify_query_var_default_when_post_type_archive_is_true() {
 		Monkey\Functions\expect( 'is_post_type_archive' )
 			->once()
-			->with()
+			->with( 'tours' )
 			->andReturn( true );
-		$query->shouldReceive( 'set')
-			->with( 'orderby', 'menu_order')
-			->once()
-			->andReturnNull();
-		$query->shouldReceive( 'set')
-		      ->with( 'order', 'DESC')
+		$query->shouldReceive( 'set' )
 		      ->once()
-			->andReturnNull();
+		      ->with( 'orderby', 'menu_order' )
+		      ->andReturn();
+		$query->shouldReceive( 'set' )
+		      ->once()
+		      ->with( 'order', 'DESC' )
+		      ->andReturn();
+		$expected = $query->query_vars = [
+			'order'   => 'ASC',
+			'orderby' => 'menu_order'
+		];
 
-		set_past_tours_by_order_number( $query );
+		$this->assertSame( $expected, set_past_tours_by_order_number( $query ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -46,8 +46,8 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 
 		require_once TOURS_ROOT_DIR . '/src/plugin.php';
 
-		$this->query             = m::mock( 'WP_Query' );
-		$this->query->query_vars = [
+		$query             = m::mock( 'WP_Query' );
+		$query->query_vars = [
 			'order'   => 'ASC',
 			'orderby' => 'menu_order'
 		];
@@ -57,32 +57,36 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
      * Test set_past_tours_by_order_number() should return unmodified query_vars from WP_Query when post_type_archive is false.
      */
 	public function test_should_return_unmodified_query_vars_when_post_type_archive_is_false() {
-		$expected = $this->query->query_vars;
+		$expected = $query->query_vars;
 
 		Monkey\Functions\expect( 'is_post_type_archive' )
 			->once()
 			->with()
 			->andReturn( false );
 
-		set_past_tours_by_order_number( $this->query );
+		set_past_tours_by_order_number( $query );
 
-		$this->assertSame( $expected, $this->query->query_vars );
+		$this->assertSame( $expected, $query->query_vars );
 	}
 
 	/*
 	 * Test set_past_tours_by_order_number() should modify query_var default when post_type_archive is true.
 	 */
-//	public function test_should_modify_query_var_default_when_post_type_archive_is_true() {
-//		Monkey\Functions\expect( 'is_post_type_archive' )
-//			->once()
-//			->with()
-//			->andReturn( true );
-//		Monkey\Functions\expect( 'set' )
-//			->once()
-//			->with( 'order', 'DESC' )
-//			->andReturnValues( 'DESC' );
-//
-//		set_past_tours_by_order_number( $this->query );
-//	}
+	public function test_should_modify_query_var_default_when_post_type_archive_is_true() {
+		Monkey\Functions\expect( 'is_post_type_archive' )
+			->once()
+			->with()
+			->andReturn( true );
+		$query->shouldReceive( 'set')
+			->with( 'orderby', 'menu_order')
+			->once()
+			->andReturnNull();
+		$query->shouldReceive( 'set')
+		      ->with( 'order', 'DESC')
+		      ->once()
+			->andReturnNull();
+
+		set_past_tours_by_order_number( $query );
+	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -35,7 +35,7 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 		$this->query = m::mock( 'WP_Query' );
 	}
 
-	/*
+	/**
      * Test set_past_tours_by_order_number() should return unmodified query_vars from WP_Query when post_type_archive is false.
      */
 	public function test_should_return_unmodified_query_vars_when_post_type_archive_is_false() {
@@ -49,7 +49,7 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 		$this->assertSame( $expected, set_past_tours_by_order_number( $this->query ) );
 	}
 
-	/*
+	/**
 	 * Test set_past_tours_by_order_number() should modify query_var default when post_type_archive is true.
 	 */
 	public function test_should_modify_query_var_default_when_post_type_archive_is_true() {

--- a/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
+++ b/plugins/tours/tests/phpunit/unit/setPastToursByOrderNumber.php
@@ -52,16 +52,17 @@ class Tests_SetPastToursByOrderNumber extends Test_Case {
 	 * Test set_past_tours_by_order_number() should modify query_var default when tours post_type_archive is true.
 	 */
 	public function test_should_modify_query_var_default_when_tours_post_type_archive_is_true() {
-		Monkey\Functions\expect( 'is_post_type_archive' )
-			->once()
-			->with( 'tours' )
-			->andReturn( true );
-
 		$query             = m::mock( 'WP_Query' );
 		$query->query_vars = [
 			'order'   => 'ASC',
 			'orderby' => 'menu_order',
 		];
+
+		Monkey\Functions\expect( 'is_post_type_archive' )
+			->once()
+			->with( 'tours' )
+			->andReturn( true );
+		
 		$query->shouldReceive( 'set' )
 		      ->once()
 		      ->with( 'orderby', 'menu_order' )


### PR DESCRIPTION
## PR Summary 

This PR contains unit and integration tests for the function `set_past_tours_by_order_number( $query )` in the `tours` plugin. This function hooks into the 'pre_get_posts' action, and provides access to an instance of the `WP_Query` object before the actual query is run in The Loop. The function modifies the `$query_vars` array by changing the `order` query_var from "DESC" to "ASC", and setting the `orderby` query_var to 'menu_order'. 

The relative path to the plugin file that contains the function is: 

> `/tours/src/plugin.php`.


