### PR TITLE
Fixes tests and composer. Switches to data provider.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,8 @@
 		"test-unit": "\"tests/vendor/bin/phpunit\" --testsuite unit --configuration tests/phpunit/unit/phpunit.xml.dist --color=always",
 		"test-integration": "\"tests/vendor/bin/phpunit\" --testsuite integration --configuration tests/phpunit/integration/phpunit.xml.dist --color=always",
 		"run-tests": [
-			"@run-unit-tests",
-			"@run-integration-tests"
+			"@test-unit",
+			"@test-integration"
 		]
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/integration/meta-data/registerMetaBoxes.php
@@ -2,9 +2,9 @@
 /**
  * Tests for the function register_meta_boxes().
  *
- * @package     spiralWebDb\centralHub\Tests\Unit\Metadata
  * @since       1.3.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\centralHub\Tests\Unit\Metadata
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
@@ -16,17 +16,17 @@ use function KnowTheCode\ConfigStore\loadConfig;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 
 /**
- * Class Tests_RegisterMetaBoxes
+ * @covers ::\spiralWebDB\Metadata\register_meta_boxes
+ * @uses    ::\spiralWebDB\Metadata\get_meta_box_keys
+ * @uses    ::\spiralWebDB\Metadata\get_meta_box_id
+ * @uses    ::\KnowTheCode\ConfigStore\getConfigParameter
  *
- * @package spiralWebDb\centralHub\Tests\Integration\Metadata
  * @group   meta-data
  */
 class Tests_RegisterMetaBoxes extends Test_Case {
 
-	/**
-	 * Empty the store before starting these tests.
-	 */
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		self::empty_the_store();
 	}
 
@@ -43,151 +43,144 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 	}
 
 	/**
-	 * Test register_meta_boxes() should register the configured meta box with WordPress.
+	 * @dataProvider addShouldRegisterTestData
 	 */
-	function test_should_register_configured_meta_box_with_wordpress() {
-		$configs = [
-			'meta_box.events' => [
-				'add_meta_box' => [
-					'id'            => 'events',
-					'title'         => 'Event Info',
-					'screen'        => 'events',
-					'context'       => 'advanced',
-					'priority'      => 'default',
-					'callback_args' => null,
-				],
-			],
-		];
-		foreach ( $configs as $store_key => $config_to_store ) {
-			loadConfig( $store_key, $config_to_store );
-		}
-
+	public function test_should_register_metaboxes( $configs ) {
 		global $wp_meta_boxes;
 
-		// Test state prior to registering the meta box.
-		$this->assertArrayNotHasKey( 'events', $wp_meta_boxes );
-
-		register_meta_boxes();
-
-		// Test the meta box is registered.
-		$this->assertArrayHasKey( 'events', $wp_meta_boxes['events']['advanced']['default'] );
-		$meta_box = $wp_meta_boxes['events']['advanced']['default']['events'];
-		$this->assertSame( $configs['meta_box.events']['add_meta_box']['id'], $meta_box['id'] );
-		$this->assertSame( $configs['meta_box.events']['add_meta_box']['title'], $meta_box['title'] );
-		$this->assertSame( 'spiralWebDB\Metadata\render_meta_box', $meta_box['callback'] );
-		$this->assertNull( $meta_box['args'] );
-
-		// Clean up.
-		self::remove_from_store( 'meta_box.events' );
-		unset( $wp_meta_boxes['events'] );
-	}
-
-	/**
-	 * Test register_meta_boxes() should register multiple configured meta boxes with WordPress.
-	 */
-	function test_should_register_multiple_configured_meta_boxes_with_wordpress() {
-		$configs = [
-			'meta_box.events'     => [
-				'add_meta_box' => [
-					'id'            => 'events',
-					'title'         => 'Event Info',
-					'screen'        => 'events',
-					'context'       => 'advanced',
-					'priority'      => 'default',
-					'callback_args' => null,
-				],
-			],
-			'meta_box.members'    => [
-				'add_meta_box' => [
-					'id'            => 'members',
-					'title'         => 'Tour Member Profile Information',
-					'screen'        => [ 'members' ],
-					'context'       => 'advanced',
-					'priority'      => 'default',
-					'callback_args' => null,
-				],
-			],
-			'meta_box.reviews'    => [
-				'add_meta_box' => [
-					'id'            => 'reviews',
-					'title'         => 'Cornerstone Reviews',
-					'screen'        => [ 'reviews' ],
-					'context'       => 'advanced',
-					'priority'      => 'default',
-					'callback_args' => null,
-				],
-			],
-		];
 		foreach ( $configs as $store_key => $config_to_store ) {
 			loadConfig( $store_key, $config_to_store );
-		}
-		$metabox_ids = [ 'events', 'members', 'reviews' ];
 
-		global $wp_meta_boxes;
+			$mb_config = $config_to_store['add_meta_box'];
 
-		// Test state prior to registering the meta box.
-		foreach ( $metabox_ids as $id ) {
-			$this->assertArrayNotHasKey( $id, $wp_meta_boxes );
-		}
+			// Test state prior to registering the meta box.
+			foreach( (array) $mb_config['screen']  as $screen ) {
+				$this->assertArrayNotHasKey( $screen, $wp_meta_boxes );
+			}
 
-		register_meta_boxes();
+			register_meta_boxes();
 
-		// Check that only the expected meta boxes are registered.
-		$this->assertSame( $metabox_ids, array_keys( $wp_meta_boxes ) );
+			foreach( (array) $mb_config['screen'] as $screen ) {
+				// Test the meta box is registered.
+				$this->assertArrayHasKey( $screen, $wp_meta_boxes );
 
-		// Test the meta boxes are registered.
-		foreach ( $metabox_ids as $id ) {
-			$this->assertArrayHasKey( $id, $wp_meta_boxes[ $id ]['advanced']['default'] );
-			$meta_box = $wp_meta_boxes[ $id ]['advanced']['default'][ $id ];
-			$this->assertSame( $configs["meta_box.{$id}"]['add_meta_box']['id'], $meta_box['id'] );
-			$this->assertSame( $configs["meta_box.{$id}"]['add_meta_box']['title'], $meta_box['title'] );
-			$this->assertSame( 'spiralWebDB\Metadata\render_meta_box', $meta_box['callback'] );
-			$this->assertNull( $meta_box['args'] );
-		}
+				$meta_box = $wp_meta_boxes[ $screen ][ $mb_config['context'] ][ $mb_config['priority'] ][ $mb_config['id'] ];
+				$this->assertSame( $mb_config['id'], $meta_box['id'] );
+				$this->assertSame( $mb_config['title'], $meta_box['title'] );
+				$this->assertSame( 'spiralWebDB\Metadata\render_meta_box', $meta_box['callback'] );
+				$this->assertSame( $mb_config['callback_args'], $meta_box['args'] );
 
-		// Clean up.
-		self::empty_the_store( $configs );
-		foreach ( $metabox_ids as $id ) {
-			unset( $wp_meta_boxes[ $id ] );
+				// Clean up.
+				unset( $wp_meta_boxes[ $screen ] );
+			}
+
+			self::remove_from_store( $store_key );
 		}
 	}
 
-	/**
-	 * Test register_meta_boxes() should not register meta boxes when there are no store keys that start with
-	 * 'meta_box.'.
-	 */
-	public function test_should_not_register_meta_boxes_when_no_store_keys_start_with_meta_box() {
-		$configs = [
-			'taxonomy.roles'         => [
-				'Soprano' => 'Soprano (vocalist)',
+	public function addShouldRegisterTestData() {
+		return [
+			[
+				'configs' => [
+					'meta_box.events' => [
+						'add_meta_box' => [
+							'id'            => 'events',
+							'title'         => 'Event Info',
+							'screen'        => 'events',
+							'context'       => 'advanced',
+							'priority'      => 'default',
+							'callback_args' => null,
+						],
+					],
+				],
 			],
-			'shortcode.qa'           => [
-				'Question 1' => 'How many angels can dance on the head of a pin?',
-			],
-			'custom_post_type.books' => [
-				'Title' => 'To Kill a Mockingbird',
-			],
-			'metabox.notametabox' => [
-				'add_meta_box' => [
-					'id'     => 'notametabox',
-					'title'  => 'Does not start with the right meta_box. structure',
-					'screen' => [ 'notametabox' ],
+			[
+				'configs' => [
+					'meta_box.events'  => [
+						'add_meta_box' => [
+							'id'            => 'events',
+							'title'         => 'Event Info',
+							'screen'        => [ 'events' ],
+							'context'       => 'advanced',
+							'priority'      => 'default',
+							'callback_args' => null,
+						],
+					],
+					'meta_box.members' => [
+						'add_meta_box' => [
+							'id'            => 'members',
+							'title'         => 'Tour Member Profile Information',
+							'screen'        => [ 'members' ],
+							'context'       => 'advanced',
+							'priority'      => 'default',
+							'callback_args' => null,
+						],
+					],
+					'meta_box.reviews' => [
+						'add_meta_box' => [
+							'id'            => 'reviews',
+							'title'         => 'Cornerstone Reviews',
+							'screen'        => 'reviews',
+							'context'       => 'advanced',
+							'priority'      => 'default',
+							'callback_args' => null,
+						],
+					],
 				],
 			],
 		];
+	}
+
+	/**
+	 * @dataProvider addShouldNotRegisterTestData
+	 */
+	public function test_should_not_register_metaboxes( $configs ) {
+		global $wp_meta_boxes;
+		$meta_boxes_before = $wp_meta_boxes;
+
 		foreach ( $configs as $store_key => $config_to_store ) {
 			loadConfig( $store_key, $config_to_store );
 		}
-
-		global $wp_meta_boxes;
-		$pre = $wp_meta_boxes;
 
 		register_meta_boxes();
 
 		// Test that no additional meta boxes were registered.
-		$this->assertSame( $pre, $wp_meta_boxes );
+		$this->assertSame( $meta_boxes_before, $wp_meta_boxes );
 
 		// Clean up.
 		self::empty_the_store( $configs );
+	}
+
+	public function addShouldNotRegisterTestData() {
+		return [
+			[
+				'configs' => [
+					'taxonomy.roles' => [
+						'Soprano' => 'Soprano (vocalist)',
+					],
+				],
+			],
+			[
+				'configs' => [
+					'shortcode.qa' => [
+						'Question 1' => 'How many angels can dance on the head of a pin?',
+					],
+				],
+			],
+			[
+				'configs' => [
+					'custom_post_type.books' => [
+						'Title' => 'To Kill a Mockingbird',
+					],
+					'metabox.notametabox'    => [
+						'add_meta_box' => [
+							'id'     => 'notametabox',
+							'title'  => 'Does not start with the right meta_box. structure',
+							'screen' => [ 'notametabox' ],
+						],
+					],
+				],
+			],
+		];
 	}
 }

--- a/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
+++ b/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php
@@ -2,23 +2,25 @@
 /**
  * Tests for the function register_meta_boxes().
  *
- * @package     spiralWebDb\centralHub\Tests\Unit\Metadata
  * @since       1.3.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\centralHub\Tests\Unit\Metadata
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
 
 namespace spiralWebDb\centralHub\Tests\Unit\Metadata;
 
-use Brain\Monkey;
+use Brain\Monkey\Functions;
 use function spiralWebDB\Metadata\register_meta_boxes;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 
 /**
- * Class Tests_RegisterMetaBoxes
+ * @covers ::\spiralWebDB\Metadata\register_meta_boxes
+ * @uses    ::\spiralWebDB\Metadata\get_meta_box_keys
+ * @uses    ::\spiralWebDB\Metadata\get_meta_box_id
+ * @uses    ::\KnowTheCode\ConfigStore\getConfigParameter
  *
- * @package spiralWebDb\centralHub\Tests\Unit\Metadata
  * @group   meta-data
  */
 class Tests_RegisterMetaBoxes extends Test_Case {
@@ -31,37 +33,60 @@ class Tests_RegisterMetaBoxes extends Test_Case {
 
 		require_once CENTRAL_HUB_ROOT_DIR . '/src/meta-data/meta-box.php';
 	}
-	
+
 	/*
 	 * Test register_meta_boxes() will add a meta box for each store key that starts with 'metabox.'.
 	 */
 	function test_function_will_add_a_meta_box_for_each_store_key_that_starts_with_metabox() {
-		Monkey\Functions\expect( 'spiralWebDB\Metadata\get_meta_box_keys' )
+		$config = [
+			'title'         => 'Events',
+			'screen'        => [ 'events' ],
+			'context'       => 'advanced',
+			'priority'      => 'default',
+			'callback_args' => null,
+		];
+
+		Functions\expect( 'spiralWebDB\Metadata\get_meta_box_keys' )
 			->once()
 			->withNoArgs()
 			->andReturn( [ 'meta_box.events' ] );
-		Monkey\Functions\expect( 'KnowTheCode\ConfigStore\getConfigParameter' )
+		Functions\expect( 'KnowTheCode\ConfigStore\getConfigParameter' )
 			->once()
-			->with( 'meta_box.events', 'add_meta_box' );
-		Monkey\Functions\when( 'spiralWebDB\Metadata\add_meta_box' )
-			->justReturn( 'events' );
-		Monkey\Functions\expect( 'spiralWebDB\Metadata\get_meta_box_id' )
+			->with( 'meta_box.events', 'add_meta_box' )
+			->andReturn( $config );
+		Functions\expect( 'spiralWebDB\Metadata\get_meta_box_id' )
 			->once()
 			->with( 'meta_box.events' )
 			->andReturn( 'events' );
+		Functions\expect( 'spiralWebDB\Metadata\add_meta_box' )
+			->once()
+			->with(
+				'events',
+				$config['title'],
+				'spiralWebDB\Metadata\render_meta_box',
+				$config['screen'],
+				$config['context'],
+				$config['priority'],
+				$config['callback_args']
+			)
+			->andReturnNull();
 
-		$this->assertNull( register_meta_boxes() );
+		register_meta_boxes();
 	}
 
 	/*
 	 * Test register_meta_boxes() returns null when no store key starts with 'metabox.'.
 	 */
 	public function test_function_should_return_null_when_no_store_key_starts_with_metabox() {
-		Monkey\Functions\expect( 'spiralWebDB\Metadata\get_meta_box_keys' )
+		Functions\expect( 'spiralWebDB\Metadata\get_meta_box_keys' )
 			->once()
 			->withNoArgs()
 			->andReturn( [] );
 
-		$this->assertNull( register_meta_boxes() );
+		Functions\expect( 'KnowTheCode\ConfigStore\getConfigParameter' )->never();
+		Functions\expect( 'add_meta_box' )->never();
+		Functions\expect( 'spiralWebDB\Metadata\get_meta_box_id' )->never();
+
+		register_meta_boxes();
 	}
 }

--- a/plugins/cornerstone-members/src/admin/edit-form-advanced.php
+++ b/plugins/cornerstone-members/src/admin/edit-form-advanced.php
@@ -35,11 +35,9 @@ function change_title_placeholder_text( $text ) {
 
 add_action( 'edit_form_before_permalink', __NAMESPACE__ . '\add_description_beneath_post_title' );
 /**
- *  Add description beneath post title custom field.
+ * Add description beneath post title custom field.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function add_description_beneath_post_title() {
 	if ( 'members' == get_post_type() ) {

--- a/plugins/tours/src/admin/wp-list-table.php
+++ b/plugins/tours/src/admin/wp-list-table.php
@@ -43,14 +43,12 @@ function _render_custom_column_content( $column_name, $tour_id ) {
 	switch ( $column_name ) {
 		case 'tour_id':
 			echo (int) $tour_id;
-			break;
+			return;
 		case 'tour_year':
-			$tour_year = (int) get_post_meta( $tour_id, 'tour_year', true );
-			echo esc_html( $tour_year );
-			break;
+			echo (int) get_post_meta( $tour_id, 'tour_year', true );
+			return;
 		case 'menu_order':
 			echo (int) get_post_field( 'menu_order', $tour_id );
-			break;
 	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/admin/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/integration/admin/_renderCustomColumnContent.php
@@ -12,7 +12,6 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
-use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
 
 /**
  * @covers ::\spiralWebDb\CornerstoneTours\_render_custom_column_content

--- a/plugins/tours/tests/phpunit/integration/admin/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/integration/admin/_renderCustomColumnContent.php
@@ -2,9 +2,9 @@
 /**
  * Tests for _render_custom_column_content().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
@@ -12,77 +12,75 @@
 namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
 
 /**
- * Class Tests__RenderCustomColumnContent
+ * @covers ::\spiralWebDb\CornerstoneTours\_render_custom_column_content
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Integration
  * @group   tours
  * @group   admin
  */
 class Tests__RenderCustomColumnContent extends Test_Case {
 
-	/*
-	 * Test _render_custom_column_content() should echo $tour_id when column_name is 'tour_id'.
+	/**
+	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_tour_id_when_column_name_is_tour_id() {
-		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
-		$post        = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
-		$column_name = 'tour_id';
-		$expected    = $post->ID;
+	public function test_should_render_custom_column_content( $column_name, $data, $expected ) {
+		$post = $this->factory->post->create_and_get( $data['post_data'] );
+		if ( 'tour_id' === $column_name ) {
+			$expected = $post->ID;
+		}
 
-		// Run the output buffer to fire the event to which the callback is registered.
+		foreach ( $data['post_meta'] as $key => $value ) {
+			add_post_meta( $post->ID, $key, $value );
+		}
+
 		ob_start();
 		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
-		$actual = (int) ob_get_clean();
-
-		$this->assertSame( $expected, $actual );
-	}
-
-	/*
-	 * Test _render_custom_column_content() should echo $tour_year when column_name is 'tour_year'.
-	 */
-	public function test_should_echo_tour_year_when_column_name_is_tour_year() {
-		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
-		$post = self::factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
-
-		// Add post_meta to the database so we can call it.
-		add_post_meta( $post->ID, 'tour_year', '2018' );
-
-		$column_name = 'tour_year';
-		$expected    = (int) get_post_meta( $post->ID, 'tour_year', true );
-
-		// Run the output buffer to fire the event to which the callback is registered.
-		ob_start();
-		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
-		$actual = (int) ob_get_clean();
-
-		$this->assertSame( $expected, $actual );
+		$this->assertEquals( $expected, ob_get_clean() );
 
 		// Clean up database.
-		delete_post_meta( $post->ID, 'tour_year' );
+		foreach ( $data['post_meta'] as $key => $value ) {
+			delete_post_meta( $post->ID, $key );
+		}
 	}
 
-	/*
-	 * Test _render_custom_column_content() should echo $menu_order when column_name is 'menu_order'.
-	 */
-	public function test_should_echo_menu_order_when_column_name_is_menu_order() {
-		// Create and get the $tour_id for the 'tours' post_type using WordPress' factory method.
-		$post        = self::factory()->post->create_and_get(
+	public function addTestData() {
+		return [
 			[
-				'post_type'  => 'tours',
-				'menu_order' => 5
-			]
-		);
-		$column_name = 'menu_order';
-		$expected    = $post->menu_order;
-
-		// Run the output buffer to fire the event to which the callback is registered.
-		ob_start();
-		do_action( "manage_{$post->post_type}_posts_custom_column", $column_name, $post->ID );
-		$actual = (int) ob_get_clean();
-
-		$this->assertSame( $expected, $actual );
+				'column_name' => 'tour_id',
+				'tour_data'   => [
+					'post_data' => [
+						'post_type' => 'tours',
+					],
+					'post_meta' => [],
+				],
+				'expected'    => 0, // populated automatically.
+			],
+			[
+				'column_name' => 'tour_year',
+				'tour_data'   => [
+					'post_data' => [
+						'post_type' => 'tours',
+					],
+					'post_meta' => [
+						'tour_year' => 2018,
+					],
+				],
+				'expected'    => 2018,
+			],
+			[
+				'column_name' => 'menu_order',
+				'tour_data'   => [
+					'post_data' => [
+						'post_type'  => 'tours',
+						'menu_order' => 5,
+					],
+					'post_meta' => [],
+				],
+				'expected'    => 5,
+			],
+		];
 	}
 }
 

--- a/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
@@ -2,9 +2,9 @@
 /**
  * Tests for add_description_beneath_post_title().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
@@ -14,9 +14,8 @@ namespace spiralWebDb\CornerstoneTours\Tests\Integration;
 use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 
 /**
- * Class Tests_AddDescriptionBeneathPostTitle
+ * @covers ::\spiralWebDb\Members\add_description_beneath_post_title
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Integration
  * @group   tours
  * @group   admin
  */
@@ -27,7 +26,8 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 	 */
 	public function test_should_not_contain_view_when_post_type_is_post() {
 		// Create and get the post object for the 'post' post_type via the factory method.
-		$post = self::factory()->post->create_and_get();
+		$post = $this->factory->post->create_and_get();
+
 		$view_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
@@ -45,7 +45,8 @@ VIEW;
 	 */
 	public function test_should_contain_view_when_post_type_is_tours() {
 		// Create and get the post object with 'tours' post_type via the factory method.
-		$post = $this->factory()->post->create_and_get( [ 'post_type' => 'tours' ] );
+		$post = $this->factory->post->create_and_get( [ 'post_type' => 'tours' ] );
+
 		$view_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
@@ -59,4 +60,3 @@ VIEW;
 		$this->assertSame( $view_html, $actual_html );
 	}
 }
-

--- a/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/integration/admin/addDescriptionBeneathPostTitle.php
@@ -22,34 +22,10 @@ use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 
 	/**
-	 * Test add_description_beneath_post_title() should npt contain view when the post type is 'post'.
+	 * @dataProvider addTestData
 	 */
-	public function test_should_not_contain_view_when_post_type_is_post() {
-		// Create and get the post object for the 'post' post_type via the factory method.
-		$post = $this->factory->post->create_and_get();
-
-		$view_html = <<<VIEW
-<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
-VIEW;
-
-		// Run the output buffer to fire the event to which the callback is registered.
-		ob_start();
-		do_action( 'edit_form_before_permalink', $post );
-		$actual_html = ob_get_clean();
-
-		$this->assertNotContains( $view_html, $actual_html );
-	}
-
-	/**
-	 * Test add_description_beneath_post_title() should contain view when the post type is 'tours'.
-	 */
-	public function test_should_contain_view_when_post_type_is_tours() {
-		// Create and get the post object with 'tours' post_type via the factory method.
-		$post = $this->factory->post->create_and_get( [ 'post_type' => 'tours' ] );
-
-		$view_html = <<<VIEW
-<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
-VIEW;
+	public function testShouldRenderViewAsExpected( $post_data, $expected_html ) {
+		$post = $this->factory->post->create_and_get( $post_data );
 
 		// Run the output buffer to fire the event to which the callback is registered.
 		ob_start();
@@ -57,6 +33,26 @@ VIEW;
 		$actual_html = ob_get_clean();
 
 		// Test the HTML
-		$this->assertSame( $view_html, $actual_html );
+		$this->assertSame( $expected_html, $actual_html );
+	}
+
+	public function addTestData() {
+		return [
+			'test_should_not_contain_view_when_post_type_is_post' => [
+				'post_data' => [
+					'post_type' => 'post',
+				],
+				'expected'  => '',
+			],
+			'test_should_contain_view_when_post_type_is_tours'    => [
+				'post_data' => [
+					'post_type' => 'tours',
+				],
+				'expected'  => <<<VIEW
+<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
+VIEW
+				,
+			],
+		];
 	}
 }

--- a/plugins/tours/tests/phpunit/unit/admin/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/admin/_renderCustomColumnContent.php
@@ -16,9 +16,8 @@ use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
 
 /**
- * Class Tests__RenderCustomColumnContent
+ * @covers ::\spiralWebDb\CornerstoneTours\_render_custom_column_content
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Unit
  * @group   tours
  * @group   admin
  */

--- a/plugins/tours/tests/phpunit/unit/admin/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/admin/_renderCustomColumnContent.php
@@ -2,16 +2,16 @@
 /**
  * Tests for _render_custom_column_content().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
 
 namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
-use Brain\Monkey;
+use Brain\Monkey\Functions;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
 
@@ -34,62 +34,61 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 	}
 
 	/**
-	 *  Test _render_custom_column_content() should echo 'tour_id' when $tour_id is given.
+	 * @dataProvider addTestData
 	 */
-	public function test_should_echo_tour_id_when_column_name_is_tour_id() {
-		$tour_id = 99;
+	public function test_should_render_custom_column_content( $column_name, $data, $expected ) {
+		if ( 'tour_id' === $column_name ) {
+			Functions\expect( 'get_post_meta' )->never();
+			Functions\expect( 'get_post_field' )->never();
 
-		Monkey\Functions\expect( 'get_post_meta' )
-			->once()
-			->with( $tour_id, 'tour_year', true )
-			->never();
-		Monkey\Functions\expect( 'get_post_field' )
-			->once()
-			->with( 'menu_order', $tour_id )
-			->never();
+		} elseif ( 'tour_year' === $column_name ) {
+			Functions\expect( 'get_post_meta' )
+				->once()
+				->with( $data['tour_id'], 'tour_year', true )
+				->andReturn( $expected );
+			Functions\expect( 'get_post_field' )->never();
 
-		$this->expectOutputString( $tour_id );
-		_render_custom_column_content( 'tour_id', $tour_id );
+		} elseif ( 'menu_order' === $column_name ) {
+			Functions\expect( 'get_post_field' )
+				->once()
+				->with( 'menu_order', $data['tour_id'] )
+				->andReturn( $expected );
+			Functions\expect( 'get_post_meta' )->never();
+		}
+
+		ob_start();
+		_render_custom_column_content( $column_name, $data['tour_id'] );
+		$this->assertSame( $expected, ob_get_clean() );
 	}
 
-	/*
-	 * Test _render_custom_column_content() should echo the 'tour_year' when $tour_year is given.
-	 */
-	public function test_should_echo_tour_year_when_tour_year_is_given() {
-		$tour_id   = 157;
-		$tour_year = 2018;
-
-		Monkey\Functions\expect( 'get_post_meta' )
-			->once()
-			->with( $tour_id, 'tour_year', true )
-			->andReturn( $tour_year );
-		Monkey\Functions\expect( 'get_post_field' )
-			->once()
-			->with( 'menu_order', $tour_id )
-			->never();
-
-		$this->expectOutputString( $tour_year );
-		_render_custom_column_content( 'tour_year', $tour_id );
-	}
-
-	/*
-	 * Test _render_custom_column_content() should echo the 'menu_order' when $menu_order is given.
-	 */
-	public function test_should_echo_menu_order_when_menu_order_is_given() {
-		$tour_id    = 211;
-		$menu_order = 5;
-
-		Monkey\Functions\expect( 'get_post_meta' )
-			->once()
-			->with( $tour_id, 'tour_year', true )
-			->never();
-		Monkey\Functions\expect( 'get_post_field' )
-			->once()
-			->with( 'menu_order', $tour_id )
-			->andReturn( $menu_order );
-
-		$this->expectOutputString( $menu_order );
-		_render_custom_column_content( 'menu_order', $tour_id );
+	public function addTestData() {
+		return [
+			[
+				'column_name' => 'tour_id',
+				'tour_data' => [
+					'tour_id'    => 99,
+					'tour_year'  => 2018,
+					'menu_order' => 0,
+				],
+				'expected'  => '99',
+			],
+			[
+				'column_name' => 'tour_year',
+				'tour_data' => [
+					'tour_id'    => 157,
+					'tour_year'  => 2018,
+				],
+				'expected'  => '2018',
+			],
+			[
+				'column_name' => 'menu_order',
+				'tour_data' => [
+					'tour_id'    => 211,
+					'menu_order' => 5,
+				],
+				'expected'  => '5',
+			],
+		];
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/admin/_renderCustomColumnContent.php
+++ b/plugins/tours/tests/phpunit/unit/admin/_renderCustomColumnContent.php
@@ -24,9 +24,6 @@ use function spiralWebDb\CornerstoneTours\_render_custom_column_content;
  */
 class Tests__RenderCustomColumnContent extends Test_Case {
 
-	/**
-	 * Prepares the test environment before each test.
-	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
@@ -58,7 +55,7 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 
 		ob_start();
 		_render_custom_column_content( $column_name, $data['tour_id'] );
-		$this->assertSame( $expected, ob_get_clean() );
+		$this->assertEquals( $expected, ob_get_clean() );
 	}
 
 	public function addTestData() {
@@ -70,7 +67,7 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 					'tour_year'  => 2018,
 					'menu_order' => 0,
 				],
-				'expected'  => '99',
+				'expected'  => 99,
 			],
 			[
 				'column_name' => 'tour_year',
@@ -78,7 +75,7 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 					'tour_id'    => 157,
 					'tour_year'  => 2018,
 				],
-				'expected'  => '2018',
+				'expected'  => 2018,
 			],
 			[
 				'column_name' => 'menu_order',
@@ -86,7 +83,7 @@ class Tests__RenderCustomColumnContent extends Test_Case {
 					'tour_id'    => 211,
 					'menu_order' => 5,
 				],
-				'expected'  => '5',
+				'expected'  => 5,
 			],
 		];
 	}

--- a/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
@@ -2,9 +2,9 @@
 /**
  * Tests for add_description_beneath_post_title().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
@@ -24,9 +24,6 @@ use function spiralWebDb\CornerstoneTours\add_description_beneath_post_title;
  */
 class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 
-	/**
-	 * Prepares the test environment before each test.
-	 */
 	protected function setUp() {
 		parent::setUp();
 
@@ -34,41 +31,14 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 	}
 
 	/**
-	 * Test add_description_beneath_post_title() should npt contain view when the post type is 'post'.
+	 * @dataProvider addTestData
 	 */
-	public function test_should_not_contain_view_when_post_type_is_post() {
+	public function testShouldRenderViewAsExpected( $post_type, $expected_html ) {
 		$post = Mockery::mock( 'WP_Post' );
 		Functions\expect( 'get_post_type' )
 			->once()
 			->with( $post )
-			->andReturn( 'post' );
-
-		$view_html = <<<VIEW
-<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
-VIEW;
-
-		// Fire the rendering function and grab the HTML out of the buffer.
-		ob_start();
-		add_description_beneath_post_title( $post );
-		$actual_html = ob_get_clean();
-
-		$this->assertEmpty( $actual_html );
-		$this->assertNotContains( $view_html, $actual_html );
-	}
-
-	/**
-	 * Test add_description_beneath_post_title() should contain view when the post type is 'tours'.
-	 */
-	public function test_should_contain_view_when_post_type_is_tours() {
-		$post = Mockery::mock( 'WP_Post' );
-		Functions\expect( 'get_post_type' )
-			->once()
-			->with( $post )
-			->andReturn( 'tours' );
-
-		$view_html = <<<VIEW
-<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
-VIEW;
+			->andReturn( $post_type );
 
 		// Fire the rendering function and grab the HTML out of the buffer.
 		ob_start();
@@ -76,6 +46,22 @@ VIEW;
 		$actual_html = ob_get_clean();
 
 		// Test the HTML.
-		$this->assertSame( $view_html, $actual_html );
+		$this->assertSame( $expected_html, $actual_html );
+	}
+
+	public function addTestData() {
+		return [
+			'test_should_contain_view_when_post_type_is_tours' => [
+				'post_type' => 'post',
+				'expected'  => '',
+			],
+			'test_should_contain_view_when_post_type_is_tours' => [
+				'post_type' => 'tours',
+				'expected'  => <<<VIEW
+<span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
+VIEW
+				,
+			],
+		];
 	}
 }

--- a/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
@@ -24,8 +24,8 @@ use function spiralWebDb\CornerstoneTours\add_description_beneath_post_title;
  */
 class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 
-	protected function setUp() {
-		parent::setUp();
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 
 		require_once TOURS_ROOT_DIR . '/src/admin/edit-form-advanced.php';
 	}

--- a/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
+++ b/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php
@@ -11,14 +11,14 @@
 
 namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
-use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\add_description_beneath_post_title;
 
 /**
- * Class Tests_AddDescriptionBeneathPostTitle
+ * @covers ::\spiralWebDb\CornerstoneTours\add_description_beneath_post_title
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Unit
  * @group   tours
  * @group   admin
  */
@@ -37,9 +37,12 @@ class Tests_AddDescriptionBeneathPostTitle extends Test_Case {
 	 * Test add_description_beneath_post_title() should npt contain view when the post type is 'post'.
 	 */
 	public function test_should_not_contain_view_when_post_type_is_post() {
-		Monkey\Functions\expect( 'get_post_type' )
+		$post = Mockery::mock( 'WP_Post' );
+		Functions\expect( 'get_post_type' )
 			->once()
+			->with( $post )
 			->andReturn( 'post' );
+
 		$view_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
@@ -57,9 +60,12 @@ VIEW;
 	 * Test add_description_beneath_post_title() should contain view when the post type is 'tours'.
 	 */
 	public function test_should_contain_view_when_post_type_is_tours() {
-		Monkey\Functions\expect( 'get_post_type' )
+		$post = Mockery::mock( 'WP_Post' );
+		Functions\expect( 'get_post_type' )
 			->once()
+			->with( $post )
 			->andReturn( 'tours' );
+
 		$view_html = <<<VIEW
 <span class="description">Enter the theme name above for this Cornerstone tour. In the editor below, add each of the venues and locations (city, state) where Cornerstone performed on this tour. Below the editor, enter additional tour information in the box labeled "Past Tour Custom Fields".</span>
 VIEW;
@@ -73,4 +79,3 @@ VIEW;
 		$this->assertSame( $view_html, $actual_html );
 	}
 }
-


### PR DESCRIPTION
- The composer `'run-tests'` script was not working as it was referencing scripts that did not exist. This PR fixes that.

- Once fixed, several tests were failing. This PR fixes those issues.

Here's the problems when running `composer test-unit`:

```
composer test-unit
> "tests/vendor/bin/phpunit" --testsuite unit --configuration tests/phpunit/unit/phpunit.xml.dist --color=always
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.1 with Xdebug 2.9.0
Configuration: /Users/hellofromtonya/Local Sites/cornerstone/app/public/wp-content/tests/phpunit/unit/phpunit.xml.dist

.............................................E................... 65 / 81 ( 80%)
.......R99R2018R5EE....                                                  81 / 81 (100%)

Time: 1.78 seconds, Memory: 14.00MB

There were 3 errors:

1) spiralWebDb\centralHub\Tests\Unit\Metadata\Tests_RegisterMetaBoxes::test_function_will_add_a_meta_box_for_each_store_key_that_starts_with_metabox
Trying to access array offset on value of type null

/Users/hellofromtonya/Local Sites/cornerstone/app/public/wp-content/mu-plugins/central-hub/src/meta-data/meta-box.php:35
/Users/hellofromtonya/Local Sites/cornerstone/app/public/wp-content/mu-plugins/central-hub/tests/phpunit/unit/meta-data/registerMetaBoxes.php:53

2) spiralWebDb\CornerstoneTours\Tests\Unit\Tests_AddDescriptionBeneathPostTitle::test_should_not_contain_view_when_post_type_is_post
Undefined variable: post

/Users/hellofromtonya/Local Sites/cornerstone/app/public/wp-content/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php:49

3) spiralWebDb\CornerstoneTours\Tests\Unit\Tests_AddDescriptionBeneathPostTitle::test_should_contain_view_when_post_type_is_tours
Undefined variable: post

/Users/hellofromtonya/Local Sites/cornerstone/app/public/wp-content/plugins/tours/tests/phpunit/unit/admin/addDescriptionBeneathPostTitle.php:69

--

There were 3 risky tests:

1) spiralWebDb\CornerstoneTours\Tests\Unit\Tests__RenderCustomColumnContent::test_should_echo_tour_id_when_column_name_is_tour_id
This test printed output: 99

2) spiralWebDb\CornerstoneTours\Tests\Unit\Tests__RenderCustomColumnContent::test_should_echo_tour_year_when_tour_year_is_given
This test printed output: 2018

3) spiralWebDb\CornerstoneTours\Tests\Unit\Tests__RenderCustomColumnContent::test_should_echo_menu_order_when_menu_order_is_given
This test printed output: 5

ERRORS!
Tests: 81, Assertions: 221, Errors: 3, Risky: 3.
```

Other changes in this PR:

- converts those tests to use data provider instead of separate test methods
- adds `@covers` for code coverage