### PR TITLE
PR#75 (_setCustomColumns | add @dataProvider method)

### DIFF
--- a/plugins/tours/tests/phpunit/integration/admin/_setCustomColumns.php
+++ b/plugins/tours/tests/phpunit/integration/admin/_setCustomColumns.php
@@ -2,9 +2,9 @@
 /**
  * Tests for _set_custom_columns().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
@@ -15,27 +15,33 @@ use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
 use function spiralWebDb\CornerstoneTours\_set_custom_columns;
 
 /**
- * Class Tests_SetCustomColumns
+ * @covers ::\spiralWebDb\CornerstoneTours\_set_custom_columns
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Integration
  * @group   tours
  * @group   admin
  */
 class Tests__SetCustomColumns extends Test_Case {
 
-	/*
-     * Test _set_custom_columns() should return expected array of custom admin columns.
-     */
-	public function test_should_return_expected_array_of_custom_columns() {
-		 $expected = [
-			 'cb'         => '<input type="checkbox"/>',
-			 'title'      => 'Tour Name',
-			 'tour_id'    => 'Tour ID',
-			 'tour_year'  => 'Tour Year',
-			 'menu_order' => 'Order Number',
-		];
+	/**
+	 * @dataProvider addTestData
+	 */
+	public function test_should_return_expected_array_of_custom_columns( $expected_columns ) {
+		
+		$this->assertSame( $expected_columns, _set_custom_columns() );
+	}
 
-		$this->assertSame( $expected, _set_custom_columns() );
+	public function addTestData() {
+		return [
+			'custom_admin_columns' => [
+				'expected_columns' => [
+					'cb'         => '<input type="checkbox"/>',
+					'title'      => 'Tour Name',
+					'tour_id'    => 'Tour ID',
+					'tour_year'  => 'Tour Year',
+					'menu_order' => 'Order Number',
+				]
+			]
+		];
 	}
 }
 


### PR DESCRIPTION
## Add dataProvider to integration test file

- Reorder @package namespace in file header.
- Add @covers annotation to test class docblock.
- Add @dataProvier annotation to test method.
- Add param from dataProvider to test method.
- Refactor test method.
- Add dataProvider method 'addTestData'.