### PR TITLE
PR#77 (registerTheTemplateFiles | add @dataProvider method)

### DIFF
--- a/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/integration/registerTheTemplateFiles.php
@@ -2,9 +2,9 @@
 /**
  * Tests for register_the_template_files().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Integration
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
@@ -16,9 +16,8 @@ use function spiralWebDb\CornerstoneTours\_get_plugin_directory;
 use function spiralWebDb\CornerstoneTours\register_the_template_files;
 
 /**
- * Class Tests_RegisterTheTemplateFiles
+ * @covers ::\spiralWebDb\CornerstoneTours\register_the_template_files
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Integration
  * @group   tours
  * @group   admin
  */
@@ -33,27 +32,48 @@ class Tests_RegisterTheTemplateFiles extends Test_Case {
 	}
 
 	/**
-	 * Test register_the_template_files() should return an array of configuration template files when given an empty templates array.
+	 * @dataProvider addTestData
+	 *
+	 * @param array $templates Array of templates to merge with configuration array.
+	 * @param array $config    Configuration of templates array loaded from plugin.
 	 */
-	public function test_should_return_an_array_of_configuration_template_files_given_an_empty_templates_array() {
-		$config = require _get_plugin_directory() . '/config/templates.php';
-
-		$this->assertSame( $config, register_the_template_files( [] ) );
+	public function test_merge_of_configuration_template_files_with_templates_array( array $templates, array $config ) {
+		if ( empty( $templates ) ) {
+			$this->assertSame( $config, register_the_template_files( (array) $templates ) );
+		} else {
+			$this->assertSame( array_merge_recursive( $templates, $config ), register_the_template_files( (array) $templates ) );
+		}
 	}
 
-	/**
-	 * Test register_the_template_files() should return a merged array of configuration template files when given a templates array.
-	 */
-	public function test_should_return_a_merged_array_of_config_template_files_when_given_a_templates_array()   {
-		$templates = [
-			'single' => [
-				'baz' => __DIR__ . '/baz/templates.php',
+	public function addTestData() {
+		return [
+			'empty_templates_array' => [
+				'templates' => [],
+				'config'    => [
+					'single'            => [
+						'tours' => _get_plugin_directory() . '/src/template/single-tours.php',
+					],
+					'post_type_archive' => [
+						'tours' => _get_plugin_directory() . '/src/template/archive-tours.php',
+					],
+				],
+			],
+			'non_empty_templates_array'    => [
+				'templates' => [
+					'single' => [
+						'baz' => __DIR__ . '/baz/templates.php',
+					]
+				],
+				'config'    => [
+					'single'            => [
+						'tours' => _get_plugin_directory() . '/src/template/single-tours.php',
+					],
+					'post_type_archive' => [
+						'tours' => _get_plugin_directory() . '/src/template/archive-tours.php',
+					],
+				],
 			]
 		];
-		$config = require _get_plugin_directory() . '/config/templates.php';
-
-		$this->assertSame( array_merge_recursive( $templates, $config ), register_the_template_files( (array) $templates ) );
 	}
 }
-
 

--- a/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
@@ -2,23 +2,22 @@
 /**
  * Tests for register_the_template_files().
  *
- * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @since       1.0.0
  * @author      Robert Gadon <rgadon107>
+ * @package     spiralWebDb\CornerstoneTours\Tests\Unit
  * @link        https://github.com/rgadon107/cornerstone
  * @license     GNU-2.0+
  */
 
 namespace spiralWebDb\CornerstoneTours\Tests\Unit;
 
-use Brain\Monkey;
+use Brain\Monkey\Functions;
 use spiralWebDb\Cornerstone\Tests\Unit\Test_Case;
 use function spiralWebDb\CornerstoneTours\register_the_template_files;
 
 /**
- * Class Tests_RegisterTheTemplateFiles
+ * @covers ::\spiralWebDb\CornerstoneTours\register_the_template_files
  *
- * @package spiralWebDb\CornerstoneTours\Tests\Unit
  * @group   tours
  */
 class Tests_RegisterTheTemplateFiles extends Test_Case {
@@ -31,49 +30,55 @@ class Tests_RegisterTheTemplateFiles extends Test_Case {
 
 		require_once TOURS_ROOT_DIR . '/src/config-loader.php';
 
-		Monkey\Functions\expect( 'spiralWebDb\CornerstoneTours\_get_plugin_directory' )
+		Functions\expect( 'spiralWebDb\CornerstoneTours\_get_plugin_directory' )
 			->times( 3 )
 			->with()
 			->andReturn( TOURS_ROOT_DIR );
 	}
 
 	/**
-	 * Test register_the_template_files() should return an array of configuration template files when given an empty
-	 * templates array.
+	 * @dataProvider addTestData
+	 *
+	 * @param array $templates Array of templates to merge with configuration array.
+	 * @param array $config    Configuration of templates array loaded from plugin.
 	 */
-	public function test_should_return_an_array_of_configuration_template_files_given_an_empty_templates_array() {
-		$templates = [];
-		$config = [
-			'single' => [
-				'tours' => TOURS_ROOT_DIR . '/src/template/single-tours.php',
-			],
-			'post_type_archive' => [
-				'tours' => TOURS_ROOT_DIR . '/src/template/archive-tours.php',
-			],
-		];
-
-		$this->assertSame( $config, register_the_template_files( (array) $templates ) );
+	public function test_merge_of_configuration_template_files_with_templates_array( array $templates, array $config ) {
+		if ( empty( $templates ) ) {
+			$this->assertSame( $config, register_the_template_files( (array) $templates ) );
+		} else {
+			$this->assertSame( array_merge_recursive( $templates, $config ), register_the_template_files( (array) $templates ) );
+		}
 	}
 
-	/**
-	 * Test register_the_template_files() should return a merged array of configuration template files when given a templates array.
-	 */
-	public function test_should_return_a_merged_array_of_config_template_files_when_given_a_templates_array()   {
-		$templates = [
-			'single' => [
-				'baz' => __DIR__ . '/baz/templates.php',
+	public function addTestData() {
+		return [
+			'templates_array_empty' => [
+				'templates' => [],
+				'config'    => [
+					'single'            => [
+						'tours' => TOURS_ROOT_DIR . '/src/template/single-tours.php',
+					],
+					'post_type_archive' => [
+						'tours' => TOURS_ROOT_DIR . '/src/template/archive-tours.php',
+					],
+				],
+			],
+			'templates_to_merge'    => [
+				'templates' => [
+					'single' => [
+						'baz' => __DIR__ . '/baz/templates.php',
+					]
+				],
+				'config'    => [
+					'single'            => [
+						'tours' => TOURS_ROOT_DIR . '/src/template/single-tours.php',
+					],
+					'post_type_archive' => [
+						'tours' => TOURS_ROOT_DIR . '/src/template/archive-tours.php',
+					],
+				],
 			]
 		];
-		$config = [
-			'single' => [
-				'tours' => TOURS_ROOT_DIR . '/src/template/single-tours.php',
-			],
-			'post_type_archive' => [
-				'tours' => TOURS_ROOT_DIR . '/src/template/archive-tours.php',
-			],
-		];
-
-		$this->assertSame( array_merge_recursive( $templates, $config ), register_the_template_files( (array) $templates ) );
 	}
 }
 

--- a/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
+++ b/plugins/tours/tests/phpunit/unit/registerTheTemplateFiles.php
@@ -52,7 +52,7 @@ class Tests_RegisterTheTemplateFiles extends Test_Case {
 
 	public function addTestData() {
 		return [
-			'templates_array_empty' => [
+			'empty_templates_array' => [
 				'templates' => [],
 				'config'    => [
 					'single'            => [
@@ -63,7 +63,7 @@ class Tests_RegisterTheTemplateFiles extends Test_Case {
 					],
 				],
 			],
-			'templates_to_merge'    => [
+			'non_empty_templates_array'    => [
 				'templates' => [
 					'single' => [
 						'baz' => __DIR__ . '/baz/templates.php',


### PR DESCRIPTION
## PR Summary 

This pull request adds an @dataProvider method to the unit and integration tests of the function `register_the_template_files()` in the `tours` plugin. While each test file contains slightly more code than the files they will replace, each file refactors 2 test methods into one. The dataProvider allows two different assertions to be tested using an `if/else` conditional in a single test method.