### PR TITLE
PR#82 ( _getPluginUrl | integration test only )

### DIFF
--- a/plugins/tours/tests/phpunit/integration/_getPluginUrl.php
+++ b/plugins/tours/tests/phpunit/integration/_getPluginUrl.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ *  Tests for _get_plugin_url()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\CornerstoneTours\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function spiralWebDb\CornerstoneTours\_get_plugin_directory;
+use function spiralWebDb\CornerstoneTours\_get_plugin_url;
+
+/**
+ * @covers ::\spiralWebDb\CornerstoneTours\_get_plugin_url
+ *
+ * @group   tours
+ */
+class Tests_GetPluginUrl extends Test_Case {
+
+	public function test_should_get_the_url_to_the_plugin_root_directory() {
+		$expected = plugins_url( 'tours', _get_plugin_directory() );
+
+		$this->assertEquals( $expected, _get_plugin_url() );
+	}
+}
+ 


### PR DESCRIPTION
Add integration test file for function `_get_plugin_url()` in the `tours` plugin `/bootstrap.php` file.