### PR TITLE
[WIP]PR#85 ( autoloadFiles | integration test only )

### DIFF
--- a/plugins/tours/tests/phpunit/integration/autoloadfiles.php
+++ b/plugins/tours/tests/phpunit/integration/autoloadfiles.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ *  Tests for _autoload_files()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\CornerstoneTours\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\CornerstoneTours\Tests\Integration;
+
+use spiralWebDb\Cornerstone\Tests\Integration\Test_Case;
+use function spiralWebDb\CornerstoneTours\_get_plugin_directory;
+use function spiralWebDb\CornerstoneTours\autoload_files;
+
+/**
+ * @covers ::\spiralWebDb\CornerstoneTours\autoload_files
+ *
+ * @group   tours
+ */
+class Tests_AutoloadFiles extends Test_Case {
+
+	/**
+	 * @dataProvider addTestData
+	 */
+	public function test_should_load_a_path_to_a_plugin_file_given_array_of_file_names( $plugin_files, $expected ) {
+		$files = $plugin_files;
+
+		foreach ( $files as $file ) {
+			require _get_plugin_directory() . '/src/' . $file;
+		}
+
+		autoload_files();
+
+		$this->assertSame( $expected, autoload_files() );
+	}
+
+	public function addTestData() {
+		return [
+			'plugin files and paths' => [
+				'plugin_files_to_autoload' => [
+					'config-loader.php',
+					'meta.php',
+					'plugin.php',
+					'admin/edit-form-advanced.php',
+					'admin/wp-list-table.php',
+				],
+				'expected_file_paths_to_load' => [
+					require _get_plugin_directory() . '/src/' . 'config-loader.php',
+					require _get_plugin_directory() . '/src/' . 'meta.php',
+					require _get_plugin_directory() . '/src/' . 'plugin.php',
+					require _get_plugin_directory() . '/src/' . 'admin/edit-form-advanced.php',
+					require _get_plugin_directory() . '/src/' . 'admin/wp-list-table.php',
+				]
+			]
+		];
+	}
+}
+ 

--- a/plugins/tours/tests/phpunit/integration/autoloadfiles.php
+++ b/plugins/tours/tests/phpunit/integration/autoloadfiles.php
@@ -26,21 +26,23 @@ class Tests_AutoloadFiles extends Test_Case {
 	 * @dataProvider addTestData
 	 */
 	public function test_should_load_a_path_to_a_plugin_file_given_array_of_file_names( $plugin_files, $expected ) {
-		$files = $plugin_files;
+		$files_to_autoload = [];
+		$files             = $plugin_files;
 
 		foreach ( $files as $file ) {
-			require _get_plugin_directory() . '/src/' . $file;
+			$load_file           = require _get_plugin_directory() . '/src/' . $file;
+			$files_to_autoload[] = $load_file;
 		}
 
 		autoload_files();
 
-		$this->assertSame( $expected, autoload_files() );
+		$this->assertSame( $expected, $files_to_autoload );
 	}
 
 	public function addTestData() {
 		return [
 			'plugin files and paths' => [
-				'plugin_files_to_autoload' => [
+				'plugin_files_to_autoload'    => [
 					'config-loader.php',
 					'meta.php',
 					'plugin.php',
@@ -58,4 +60,4 @@ class Tests_AutoloadFiles extends Test_Case {
 		];
 	}
 }
- 
+


### PR DESCRIPTION
This PR includes an integration test for the function `autoload_files()` in the `tours` plugin `/bootstrap.php` file. 

### Issues

@hellofromtonya The test method fails. PHPUnit throws a fatal error on the first file that `autoload_files` attempts to load into memory. That's because that same file is already loaded into memory. The first function in `config-loader.php` cannot be reloaded into memory when it already exists. 

The function under test takes a set of string literal file paths, and then loops through the array to build a set of 'paths/to/file' to load into memory. When `autoload_files` is called in `bootstrap.php`, the 'paths/to/file' are called, and the files are loaded into memory. So we know which files are to be loaded when the autoloader runs. 

The challenge is, how to confirm the expected behavior of `autoload_files` without running afoul of PHP? 